### PR TITLE
all_sample_resourceTemplates.json: updated with 'latest' from verso

### DIFF
--- a/resourceTemplates/v1/all_sample_resourceTemplates.json
+++ b/resourceTemplates/v1/all_sample_resourceTemplates.json
@@ -13,7 +13,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": "http://id.loc.gov/ontologies/bflc/catalogerId"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/catalogerId",
             "propertyLabel": "Your cataloger ID (Windows ID)"
@@ -29,7 +30,8 @@
               "valueDataType": {
                 "dataTypeLabelHint": "Date or date and time on which the original metadata first created."
               },
-              "editable": "false"
+              "editable": "false",
+              "defaults": []
             },
             "propertyLabel": "Creation date",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/creationDate"
@@ -45,13 +47,14 @@
               "valueDataType": {
                 "dataTypeLabelHint": "Date or date and time on which the metadata was modified."
               },
-              "editable": "false"
+              "editable": "false",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/changeDate",
             "propertyLabel": "Change date"
           },
           {
-            "mandatory": "false",
+            "mandatory": "true",
             "repeatable": "false",
             "type": "resource",
             "resourceTemplates": [],
@@ -63,17 +66,21 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultLiteral": "DLC",
               "editable": "false",
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "propertyLabel": "Assigning agency",
             "remark": "",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source"
           },
           {
-            "mandatory": "false",
+            "mandatory": "true",
             "repeatable": "true",
             "type": "resource",
             "resourceTemplates": [],
@@ -85,15 +92,19 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"
               },
-              "defaultLiteral": "pcc",
-              "defaultURI": "http://id.loc.gov/vocabulary/marcauthen/pcc"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/marcauthen/pcc",
+                  "defaultLiteral": "pcc"
+                }
+              ]
             },
             "propertyLabel": "Description authentication",
             "remark": "",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication"
           },
           {
-            "mandatory": "false",
+            "mandatory": "true",
             "repeatable": "false",
             "type": "resource",
             "resourceTemplates": [],
@@ -105,17 +116,21 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
               "editable": "false",
-              "defaultLiteral": "rda",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+                  "defaultLiteral": "rda"
+                }
+              ]
             },
             "propertyLabel": "Description conventions",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionConventions",
             "remark": ""
           },
           {
-            "mandatory": "false",
+            "mandatory": "true",
             "repeatable": "false",
             "type": "resource",
             "resourceTemplates": [],
@@ -128,19 +143,23 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language",
                 "dataTypeLabel": ""
               },
-              "defaultLiteral": "eng",
-              "defaultURI": "",
               "editable": "false",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+                  "defaultLiteral": "English"
+                }
+              ]
             },
             "propertyLabel": "Description language",
             "remark": "",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionLanguage"
           },
           {
-            "mandatory": "false",
+            "mandatory": "true",
             "repeatable": "true",
-            "type": "literal",
+            "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
@@ -149,9 +168,13 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
               "editable": "false",
-              "defaultLiteral": "DLC",
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "propertyLabel": "Description modifier",
             "remark": "",
@@ -169,7 +192,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/EncodingLevel"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Encoding level",
             "remark": "",
@@ -184,7 +208,278 @@
               "valueTemplateRefs": [],
               "useValuesFrom": [],
               "valueDataType": {},
-              "editable": "false"
+              "editable": "false",
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/profile",
+            "propertyLabel": "Profile",
+            "remark": "The profile code for the resource"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Identifiers:Local"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
+            "propertyLabel": "Identifier",
+            "remark": "Local Identifier"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:AdminMetadata:GenerationProcess"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {},
+              "validatePattern": ""
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/generationProcess",
+            "propertyLabel": "Generation Process"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:AdminMetadata:Status"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
+            "propertyLabel": "Status",
+            "remark": ""
+          }
+        ],
+        "id": "profile:bf2:AdminMetadata:BFDB",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
+        "resourceLabel": "BF DB Admin Metadata"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "valueDataType": {
+                "remark": "http://id.loc.gov/ontologies/bflc/catalogerId"
+              },
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/catalogerId",
+            "propertyLabel": "Your cataloger ID (Windows ID)"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "valueDataType": {
+                "dataTypeLabelHint": "Date or date and time on which the original metadata first created."
+              },
+              "editable": "false",
+              "defaults": []
+            },
+            "propertyLabel": "Creation date",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/creationDate"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "valueDataType": {
+                "dataTypeLabelHint": "Date or date and time on which the metadata was modified."
+              },
+              "editable": "false",
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/changeDate",
+            "propertyLabel": "Change date"
+          },
+          {
+            "mandatory": "true",
+            "repeatable": "false",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/organizations"
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+              },
+              "editable": "false",
+              "repeatable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
+            },
+            "propertyLabel": "Assigning agency",
+            "remark": "",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/source"
+          },
+          {
+            "mandatory": "true",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/marcauthen"
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"
+              },
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/marcauthen/pcc",
+                  "defaultLiteral": "pcc"
+                }
+              ]
+            },
+            "propertyLabel": "Description authentication",
+            "remark": "",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication"
+          },
+          {
+            "mandatory": "true",
+            "repeatable": "false",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/descriptionConventions"
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
+              },
+              "editable": "false",
+              "repeatable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+                  "defaultLiteral": "rda"
+                }
+              ]
+            },
+            "propertyLabel": "Description conventions",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionConventions",
+            "remark": ""
+          },
+          {
+            "mandatory": "true",
+            "repeatable": "false",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/languages"
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language",
+                "dataTypeLabel": ""
+              },
+              "editable": "false",
+              "repeatable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+                  "defaultLiteral": "English"
+                }
+              ]
+            },
+            "propertyLabel": "Description language",
+            "remark": "",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionLanguage"
+          },
+          {
+            "mandatory": "true",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+              },
+              "editable": "false",
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
+            },
+            "propertyLabel": "Description modifier",
+            "remark": "",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionModifier"
+          },
+          {
+            "mandatory": "true",
+            "repeatable": "false",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/menclvl"
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/EncodingLevel"
+              },
+              "defaults": []
+            },
+            "propertyLabel": "Encoding level",
+            "remark": "",
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/encodingLevel"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "false",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "editable": "false",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/profile",
             "propertyLabel": "Profile",
@@ -194,11 +489,247 @@
         "id": "profile:bf2:AdminMetadata",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
         "resourceLabel": "BIBFRAME 2.0 Admin Metadata"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/catalogerId",
+            "propertyLabel": "Your cataloger ID (Windows ID)"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/creationDate",
+            "propertyLabel": "Creation date"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/changeDate",
+            "propertyLabel": "Change date"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:AdminMetadata2:Source"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+            "propertyLabel": "Assigning agency"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/marcauthen"
+              ],
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/marcauthen/pcc",
+                  "defaultLiteral": "pcc"
+                }
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionAuthentication"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionAuthentication",
+            "propertyLabel": "Description authentication"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/descriptionConventions"
+              ],
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+                  "defaultLiteral": "RDA"
+                }
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/DescriptionConventions"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionConventions",
+            "propertyLabel": "Description conventions"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/languages"
+              ],
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+                  "defaultLiteral": "English"
+                }
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionLanguage",
+            "propertyLabel": "Description language"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:AdminMetadata2:Source"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/descriptionModifier",
+            "propertyLabel": "Description modifier"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/menclvl"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/EncodingLevel"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/encodingLevel",
+            "propertyLabel": "Encoding level"
+          }
+        ],
+        "id": "profile:bf2:AdminMetadata2",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/AdminMetadata",
+        "resourceLabel": "Admin Metadata Test"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/organizations"
+              ],
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Source/Agent"
+          }
+        ],
+        "id": "profile:bf2:AdminMetadata2:Source",
+        "resourceLabel": "Source/Agent",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Label",
+            "remark": ""
+          }
+        ],
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenerationProcess",
+        "id": "profile:bf2:AdminMetadata:GenerationProcess",
+        "resourceLabel": "Generation Process"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/code",
+            "propertyLabel": "Code"
+          }
+        ],
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Status",
+        "resourceLabel": "Status",
+        "remark": "",
+        "id": "profile:bf2:AdminMetadata:Status"
+      },
       {
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Contribution",
         "id": "profile:bf2:Agents:Contribution",
@@ -283,11 +814,7 @@
             "remark": "http://access.rdatoolkit.org/rdaappi_rdai-34.html"
           }
         ]
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -306,14 +833,15 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "repeatable": "true",
-              "editable": "true"
+              "editable": "false",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
             "propertyLabel": "Primary Contributor"
           },
           {
             "mandatory": "false",
-            "repeatable": "false",
+            "repeatable": "true",
             "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
@@ -322,7 +850,9 @@
               ],
               "useValuesFrom": [],
               "valueDataType": {},
-              "repeatable": "false"
+              "repeatable": "true",
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
             "propertyLabel": "Relationship Designator (RDA Appendix I)",
@@ -349,7 +879,8 @@
                 "profile:bf2:Agent:Conference"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
             "propertyLabel": "Primary Contributor"
@@ -364,7 +895,8 @@
                 "profile:bf2:Agent:Role"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
             "propertyLabel": "Relationship Designator (RDA Appendix I)",
@@ -374,11 +906,7 @@
         "id": "profile:bflc:Agents:bfPrimaryContribution",
         "resourceLabel": "Primary Contribution (test)",
         "resourceURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "resourceURI": "http://www.loc.gov/mads/rdf/v1#PersonalName",
         "id": "profile:bf2:Agent:Person",
@@ -395,7 +923,9 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "valueLanguage": ""
+              "valueLanguage": "",
+              "defaults": [],
+              "editable": "true"
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#PersonalName",
             "type": "lookup",
@@ -413,7 +943,9 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#PersonalName"
-              }
+              },
+              "defaults": [],
+              "editable": "true"
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Preferred Name for Person (RDA 9.2.2) CORE ELEMENT",
@@ -427,7 +959,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#fullerName",
             "propertyLabel": "Fuller Form of Name (RDA 9.5) CORE IF ...",
@@ -443,9 +976,10 @@
                 "profile:bf2:Agent:RWO"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://www.loc.gov/mads/rdf/v1#identifiesRWO",
+            "propertyURI": "http://www.loc.gov/mads/rdf/v1#isIdentifiedByAuthority",
             "propertyLabel": "Other Identifying Attributes (RDA 9.6-9.11)",
             "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5161.html"
           },
@@ -460,7 +994,8 @@
                 "profile:bf2:Agents:Addresses:Extended"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Address of Person (RDA 9.12)",
             "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5161.html",
@@ -476,7 +1011,8 @@
                 "profile:bf2:Agent:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#note",
             "propertyLabel": "Biographical Information (RDA 9.17)",
@@ -492,7 +1028,8 @@
                 "profile:bf2:Agent:Identifier"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Identifier for the Person (RDA 9.18)",
             "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5421.html",
@@ -508,7 +1045,8 @@
                 "profile:bf2:Agents:VariantAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant",
             "propertyLabel": "Variant Access Point Representing a Person (RDA 9.19.2)",
@@ -524,7 +1062,8 @@
                 "profile:bf2:Agents:RelatedAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Related Agents (RDA Chapter 30)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority",
@@ -540,15 +1079,14 @@
                 "profile:bf2:Agents:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Source Consulted (RDA 8.12)",
             "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource"
           }
-        ],
-        "contact": "",
-        "remark": ""
+        ]
       },
       {
         "resourceURI": "http://www.loc.gov/mads/rdf/v1#FamilyName",
@@ -565,7 +1103,9 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [],
+              "editable": "true"
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#FamilyName",
             "type": "lookup",
@@ -581,9 +1121,10 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://www.loc.gov/mads/rdf/v1#FamilyName",
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Preferred Name for Family (RDA 10.2.2) CORE ELEMENT",
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-241.html"
           },
@@ -595,7 +1136,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-468.html",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#FamilyNameElement",
@@ -611,7 +1153,8 @@
                 "profile:bf2:Agents:RWO:Dates"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Date Associated with Family (RDA 10.4)",
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-487.html",
@@ -627,7 +1170,8 @@
                 "profile:bf2:Agents:RWO:OtherPlace"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale",
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-516.html",
@@ -643,7 +1187,8 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Prominent Member of Family (RDA 10.6)",
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-549.html",
@@ -657,7 +1202,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-592.html",
             "propertyLabel": "Hereditary Title (RDA 10.7)",
@@ -673,7 +1219,8 @@
                 "profile:bf2:Agents:RWO:AssociatedLanguage"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-9952.html",
             "propertyLabel": "Language of Family (RDA 10.8)",
@@ -689,7 +1236,8 @@
                 "profile:bf2:Agent:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-625.html",
             "propertyLabel": "Family History (RDA 10.9)",
@@ -705,7 +1253,8 @@
                 "profile:bf2:Agent:Identifier"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-657.html",
             "propertyLabel": "Identifier for Family (RDA 10.10)",
@@ -723,7 +1272,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Authorized Access Point Representing the Family (RDA 10.11.1)",
             "remark": "http://access.rdatoolkit.org/rdachp10_rda10-678.html",
@@ -739,7 +1289,8 @@
                 "profile:bf2:Agents:VariantAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant",
             "propertyLabel": "Variant Access Point Representing the Family (RDA 10.11.2)",
@@ -755,7 +1306,8 @@
                 "profile:bf2:Agents:RelatedAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Related Agents (RDA Chapter 30)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority",
@@ -771,7 +1323,8 @@
                 "profile:bf2:Agents:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Source Consulted (RDA 8.12)",
             "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
@@ -794,7 +1347,9 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [],
+              "editable": "true"
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#CorporateName",
             "type": "lookup",
@@ -810,9 +1365,10 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://www.loc.gov/mads/rdf/v1#CorporateName",
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Preferred Name for Corporate Body (RDA 11.2.2) CORE ELEMENT",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-1207.html"
           },
@@ -826,7 +1382,8 @@
                 "profile:bf2:Agents:RWO:OtherPlace"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLocale",
             "propertyLabel": "Place Associated with Corporate Body (RDA 11.3)",
@@ -842,7 +1399,8 @@
                 "profile:bf2:Agents:RWO:Dates"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Date Associated with Corporate Body (RDA 11.4) CORE ELEMENT",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#establishDate",
@@ -858,7 +1416,8 @@
                 "profile:bf2:Agents:RWO:Affiliation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Associated Institution (RDA 11.5)",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4671.html",
@@ -872,7 +1431,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Other Designation Associated with Corporate Body (RDA 11.7)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#entityDescriptor",
@@ -888,7 +1448,8 @@
                 "profile:bf2:Agents:RWO:AssociatedLanguage"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Language of Corporate Body (RDA 11.8)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#associatedLanguage",
@@ -905,7 +1466,8 @@
                 "profile:bf2:Agents:Addresses:Extended"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Address of Corporate Body (RDA 11.9)",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5024.html",
@@ -921,7 +1483,8 @@
                 "profile:bf2:Agents:RWO:FieldofActivity"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Field of Activity of Corporate Body (RDA 11.10)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#fieldOfActivity",
@@ -937,7 +1500,8 @@
                 "profile:bf2:Agent:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Corporate History (RDA 11.11)",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5084.html",
@@ -953,7 +1517,8 @@
                 "profile:bf2:Agent:Identifier"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Identifier for the Corporate Body (RDA 11.12) CORE ELEMENT",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5119.html",
@@ -967,7 +1532,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Authorized Access Point for the Corporate Body (RDA 11.13.1)",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5161.html",
@@ -983,7 +1549,8 @@
                 "profile:bf2:Agents:VariantAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Variant Access Point Representing a Corporate Body (RDA 11.13.2)",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5591.html",
@@ -999,7 +1566,8 @@
                 "profile:bf2:Agents:RelatedAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Related Agents (RDA Chapter 30)",
             "remark": "http://access.rdatoolkit.org/rdachp30_rda30-28.html",
@@ -1015,7 +1583,8 @@
                 "profile:bf2:Agents:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Source Consulted (RDA 8.12)",
             "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
@@ -1038,7 +1607,9 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [],
+              "editable": "true"
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#ConferenceName",
             "type": "lookup",
@@ -1054,9 +1625,10 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://www.loc.gov/mads/rdf/v1#ConferenceName",
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Preferred Name for Conference (RDA 11.2.2) CORE ELEMENT",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-1207.html"
           },
@@ -1071,7 +1643,8 @@
                 "profile:bf2:Agents:RWO:OtherPlace"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Place Associated with Conference (RDA 11.3) CORE ELEMENT",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4146.html",
@@ -1087,7 +1660,8 @@
                 "profile:bf2:Agents:RWO:Dates"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4502.html",
             "propertyLabel": "Date Associated with Conference (RDA 11.4) CORE ELEMENT",
@@ -1103,11 +1677,12 @@
                 "profile:bf2:Agents:RWO:Affiliation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4671.html",
             "propertyLabel": "Associated Institution (RDA 11.5) CORE IF ...",
-            "propertyURI": "http://www.loc.gov/mads/rdf/v1#Organization"
+            "propertyURI": "http://www.loc.gov/mads/rdf/v1#organization"
           },
           {
             "mandatory": "false",
@@ -1117,11 +1692,12 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-10741.html",
             "propertyLabel": "Number of a Conference, Etc. (RDA 11.6) CORE ELEMENT",
-            "propertyURI": "http://www.loc.gov/mads/rdf/v2.html#ConferenceNumber"
+            "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
           },
           {
             "mandatory": "false",
@@ -1131,7 +1707,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4726.html",
             "propertyLabel": "Other Designation Associated with Conference (RDA 11.7) CORE IF ...",
@@ -1147,7 +1724,8 @@
                 "profile:bf2:Agents:RWO:AssociatedLanguage"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-4993.html",
             "propertyLabel": "Language of Conference (RDA 11.8)",
@@ -1163,7 +1741,8 @@
                 "profile:bf2:Agents:RWO:FieldofActivity"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5056.html",
             "propertyLabel": "Field of Activity of Conference (RDA 11.10)",
@@ -1179,7 +1758,8 @@
                 "profile:bf2:Agent:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5084.html",
             "propertyLabel": "Conference History (RDA 11.11)",
@@ -1195,7 +1775,8 @@
                 "profile:bf2:Agent:Identifier"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasIdentifier",
             "propertyLabel": "Identifier for the Conference (RDA 11.12) CORE ELEMENT",
@@ -1209,7 +1790,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Authorized Access Point for the Conference (RDA 11.13.1)",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5161.html",
@@ -1225,7 +1807,8 @@
                 "profile:bf2:Agents:VariantAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Variant Access Point Representing a Conference (RDA 11.13.2)",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5591.html",
@@ -1241,7 +1824,8 @@
                 "profile:bf2:Agents:RelatedAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Related Agents (RDA Chapter 30)",
             "remark": "http://access.rdatoolkit.org/rdachp30_rda30-28.html",
@@ -1257,7 +1841,8 @@
                 "profile:bf2:Agents:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource",
             "propertyLabel": "Source Consulted (RDA 8.12)",
@@ -1285,7 +1870,9 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [],
+              "editable": "true"
             }
           },
           {
@@ -1296,10 +1883,11 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Preferred Name for Place (RDA 16.2.2)",
-            "propertyURI": "http://www.loc.gov/mads/rdf/v1#Geographic",
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "remark": "http://access.rdatoolkit.org/rdachp16_rda16-322.html"
           },
           {
@@ -1312,7 +1900,8 @@
                 "profile:bf2:Agent:Identifier"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasIdentifier",
             "propertyLabel": "Identifier for Place (RDA 9.18)",
@@ -1326,7 +1915,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Authorized Access Point for the Place (RDA 11.13.1.1)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
@@ -1342,7 +1932,8 @@
                 "profile:bf2:Agents:VariantAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Variant Access Point Representing the Place (RDA 11.13.2)",
             "remark": "http://access.rdatoolkit.org/rdachp11_rda11-5591.html",
@@ -1358,7 +1949,8 @@
                 "profile:bf2:Agents:RelatedAgents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Related Agents (RDA Chapter 30)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasRelatedAuthority",
@@ -1374,14 +1966,14 @@
                 "profile:bf2:Agents:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Source Consulted (RDA 8.12)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasSource",
             "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html"
           }
-        ],
-        "contact": ""
+        ]
       },
       {
         "propertyTemplates": [
@@ -1396,8 +1988,12 @@
                 "http://id.loc.gov/vocabulary/organizations"
               ],
               "valueDataType": {},
-              "defaultLiteral": "DLC",
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "propertyLabel": "Record Content Source",
             "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordContentSource",
@@ -1411,7 +2007,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Record Creation Date",
             "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordCreationDate",
@@ -1425,7 +2022,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordChangeDate",
             "propertyLabel": "Record Change Date",
@@ -1439,7 +2037,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Record Identifier",
             "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordIdentifier",
@@ -1453,7 +2052,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Record Origin",
             "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordOrigin",
@@ -1467,7 +2067,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Record Info Note",
             "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#recordInfoNote",
@@ -1484,8 +2085,12 @@
                 "http://id.loc.gov/vocabulary/languages"
               ],
               "valueDataType": {},
-              "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
-              "defaultLiteral": "eng"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/languages/eng",
+                  "defaultLiteral": "eng"
+                }
+              ]
             },
             "propertyLabel": "Language of Cataloging",
             "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#languageOfCataloging",
@@ -1503,8 +2108,12 @@
               ],
               "valueDataType": {},
               "editable": "false",
-              "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
-              "defaultLiteral": "rda"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/descriptionConventions/rda",
+                  "defaultLiteral": "rda"
+                }
+              ]
             },
             "propertyLabel": "Description Standard",
             "propertyURI": "http://www.loc.gov/standards/mods/v3/mods-3-6#descriptionStandard",
@@ -1526,7 +2135,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Address of Person (RDA 9.12)",
             "remark": "http://access.rdatoolkit.org/rdachp9_rda9-5161.html",
@@ -1540,7 +2150,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Email Address of Person",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#email"
@@ -1553,7 +2164,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Address of Corporate Body (RDA 11.9)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#AffiliationAddress",
@@ -1567,7 +2179,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Email Address of Corporate Body",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#email"
@@ -1587,7 +2200,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Street Address 1",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#streetAddress"
@@ -1600,7 +2214,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Street Address 2",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#extendedAddress"
@@ -1613,7 +2228,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "City",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#city"
@@ -1626,7 +2242,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "State",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#state"
@@ -1639,7 +2256,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Country",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#country"
@@ -1652,7 +2270,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Zip Code or Post Code",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#postcode"
@@ -1676,7 +2295,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#Authority"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Search agents",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
@@ -1693,7 +2313,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Role"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Relationship Designator (RDA Appendix K)",
             "remark": "http://access.rdatoolkit.org/rdaappk_rdak-15.html",
@@ -1714,7 +2335,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#citationSource",
             "propertyLabel": "Source Consulted (RDA 8.12)",
@@ -1730,7 +2352,8 @@
                 "profile:bf2:Agent:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Source Consulted Note (RDA 8.12)",
             "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
@@ -1744,7 +2367,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Source Citation Status (RDA 8.12)",
             "remark": "http://access.rdatoolkit.org/rdachp8_rda8-479.html",
@@ -1760,7 +2384,8 @@
                 "profile:bf2:Agent:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Cataloger's Note (RDA 8.13)",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#editorialNote",
@@ -1781,7 +2406,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#hasVariant",
             "propertyLabel": "Variant Access Point Representing an Agent",
@@ -1807,7 +2433,8 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyLabel": "Search MARC relator term",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Role"
@@ -1823,7 +2450,8 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Input RDA relationship designator term (if it does not appear above)"
@@ -1843,7 +2471,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Identifier"
@@ -1858,7 +2487,8 @@
                 "profile:bf2:Agent:Identifier:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Source of identifier"
@@ -1878,7 +2508,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Note"
@@ -1898,7 +2529,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Source of identifier"
@@ -1920,7 +2552,8 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Search LCNAF",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Person"
@@ -1935,7 +2568,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Person"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Preferred Name for Person (RDA 9.2.2) CORE ELEMENT"
@@ -1944,11 +2578,7 @@
         "id": "profile:bf2:Agent:bfPerson",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Person",
         "resourceLabel": "Bibframe Person"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -1963,7 +2593,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Lookup"
@@ -1980,7 +2611,9 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -1997,7 +2630,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information"
@@ -2012,7 +2646,9 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -2027,7 +2663,9 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
             "propertyLabel": "(Geographic) Coverage of the Content"
@@ -2040,7 +2678,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
@@ -2053,14 +2692,15 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Cartographic:Coordinates"
+                "profile:bf2:Cartographic:Attributes"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/cartographicAttributes",
-            "propertyLabel": "Coordinates of Cartographic Content (RDA 7.4)",
-            "remark": "http://access.rdatoolkit.org/7.4.html"
+            "propertyLabel": "Cartographic Attributes",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -2074,7 +2714,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience (RDA 7.7)",
@@ -2090,7 +2731,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -2108,7 +2751,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -2124,7 +2768,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -2140,7 +2785,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -2152,10 +2798,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Cartographic:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -2167,10 +2814,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Cartographic:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -2188,10 +2836,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/cri",
-              "defaultLiteral": "cartographic image",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/cri",
+                  "defaultLiteral": "cartographic image"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -2211,7 +2863,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -2227,7 +2880,8 @@
                 "profile:bf2:Script"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Script (RDA 7.13.2)",
@@ -2240,10 +2894,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Cartographic:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -2258,7 +2913,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -2274,7 +2930,8 @@
                 "profile:bf2:Cartographic:Scale"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/scale",
             "propertyLabel": "Scale information"
@@ -2287,35 +2944,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/projection",
-            "propertyLabel": "Projection of Cartographic Content (RDA 7.26)",
-            "remark": "http://access.rdatoolkit.org/7.26.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/cartographicAttributes",
-            "propertyLabel": "Other Details of Cartographic Content (RDA 7.27)",
-            "remark": "http://access.rdatoolkit.org/7.27.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "Time Period of Content (MARC 045 field)"
@@ -2330,11 +2960,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-64.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -2346,7 +2977,8 @@
                 "profile:bf2:Cartographic:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -2371,7 +3003,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Cartographic:Work"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -2388,8 +3021,10 @@
               "valueTemplateRefs": [
                 "profile:bf2:Title",
                 "profile:bf2:Title:VarTitle",
-                "profile:bf2:ParallelTitle"
-              ]
+                "profile:bf2:ParallelTitle",
+                "profile:bflc:TranscribedTitle"
+              ],
+              "defaults": []
             }
           },
           {
@@ -2403,7 +3038,8 @@
             "valueConstraint": {
               "useValuesFrom": [],
               "valueDataType": {},
-              "valueTemplateRefs": []
+              "valueTemplateRefs": [],
+              "defaults": []
             }
           },
           {
@@ -2419,7 +3055,8 @@
                 ""
               ],
               "valueDataType": {},
-              "valueTemplateRefs": []
+              "valueTemplateRefs": [],
+              "defaults": []
             }
           },
           {
@@ -2437,7 +3074,8 @@
                 "profile:bf2:PublicationInformation",
                 "profile:bf2:ManufactureInformation",
                 "profile:bf2:DistributionInformation"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -2451,7 +3089,8 @@
             "valueConstraint": {
               "useValuesFrom": [],
               "valueDataType": {},
-              "valueTemplateRefs": []
+              "valueTemplateRefs": [],
+              "defaults": []
             }
           },
           {
@@ -2467,7 +3106,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:SeriesInformation"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -2486,10 +3126,14 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
               "valueTemplateRefs": [],
-              "defaultLiteral": "single unit",
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             }
           },
           {
@@ -2507,7 +3151,8 @@
                 "profile:bf2:Identifiers:ISBN",
                 "profile:bf2:Identifiers:Other",
                 "profile:bf2:Identifiers:Local"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -2523,7 +3168,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Note"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -2535,8 +3181,6 @@
             "resourceTemplates": [],
             "type": "resource",
             "valueConstraint": {
-              "defaultLiteral": "unmediated",
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
               "useValuesFrom": [
                 "http://id.loc.gov/vocabulary/mediaTypes"
               ],
@@ -2545,7 +3189,13 @@
               },
               "valueTemplateRefs": [],
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                  "defaultLiteral": "unmediated"
+                }
+              ]
             }
           },
           {
@@ -2557,8 +3207,6 @@
             "resourceTemplates": [],
             "type": "resource",
             "valueConstraint": {
-              "defaultLiteral": "volume",
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
               "useValuesFrom": [
                 "http://id.loc.gov/vocabulary/carriers"
               ],
@@ -2566,8 +3214,14 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
               "valueTemplateRefs": [],
-              "editable": "true",
-              "repeatable": "true"
+              "editable": "false",
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                  "defaultLiteral": "volume"
+                }
+              ]
             }
           },
           {
@@ -2582,8 +3236,9 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "valueTemplateRefs": [
-                "profile:bf2:Cartographic:Extent"
-              ]
+                "profile:bf2:Extent"
+              ],
+              "defaults": []
             }
           },
           {
@@ -2597,7 +3252,8 @@
             "valueConstraint": {
               "useValuesFrom": [],
               "valueDataType": {},
-              "valueTemplateRefs": []
+              "valueTemplateRefs": [],
+              "defaults": []
             }
           },
           {
@@ -2612,7 +3268,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
             "propertyLabel": "Base Material (RDA 3.6)",
@@ -2630,7 +3287,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Layout"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Layout (RDA 3.11)",
             "remark": "http://access.rdatoolkit.org/3.11.html",
@@ -2651,7 +3309,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Polarity"
               },
               "editable": "true",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyLabel": "Polarity (RDA 3.14)",
             "remark": "http://access.rdatoolkit.org/3.14.html",
@@ -2664,14 +3323,16 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Cartographic:Digital"
+                "profile:bf2:Cartographic:DataType",
+                "profile:bf2:Cartographic:ObjectType"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Digital File Characteristic (RDA 3.19)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/digitalCharacteristic",
-            "remark": "http://access.rdatoolkit.org/3.19.html"
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -2684,7 +3345,8 @@
             "valueConstraint": {
               "useValuesFrom": [],
               "valueDataType": {},
-              "valueTemplateRefs": []
+              "valueTemplateRefs": [],
+              "defaults": []
             }
           },
           {
@@ -2697,10 +3359,11 @@
                 "profile:bf2:Cartographic:Class"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Geographic Classification (MARC 052)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage"
           },
           {
             "mandatory": "false",
@@ -2712,7 +3375,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contributors (RDA 21.1)",
@@ -2728,7 +3393,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
@@ -2741,13 +3407,14 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Cartographic:RelatedInstance"
+                "profile:bf2:RelatedInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Manifestation"
+            "propertyLabel": "Related Instances"
           },
           {
             "mandatory": "false",
@@ -2759,7 +3426,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
             "propertyLabel": "Administrative Metadata for Instance"
@@ -2774,7 +3442,8 @@
                 "profile:bf2:Cartographic:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Has Item",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem"
@@ -2796,8 +3465,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
             "propertyLabel": "Held by"
@@ -2812,7 +3485,8 @@
                 "profile:bf2:Identifiers:LC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Shelving call numbers"
@@ -2827,7 +3501,8 @@
                 "profile:bf2:Identifiers:Shelfmark"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/shelfmark",
             "propertyLabel": "Copy, issue, offprint number"
@@ -2842,7 +3517,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Barcode"
@@ -2855,7 +3531,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
             "propertyLabel": "Electronic location"
@@ -2868,7 +3545,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
             "propertyLabel": "Held in sublocation"
@@ -2883,7 +3561,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Item"
@@ -2900,7 +3579,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
             "propertyLabel": "Lending, Reproduction, and Retention Policies"
@@ -2915,74 +3595,39 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/instances"
-              ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Lookup"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "literal",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
+              "defaults": [],
               "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Related Manifestation Authorized Access Point"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/relationshipTarget",
-            "propertyLabel": "Relationship Designator for Related Manifestation (RDA Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdaappj_rdaj-15.html"
-          }
-        ],
-        "id": "profile:bf2:Cartographic:RelatedInstance",
-        "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
-        "resourceLabel": "Related Instance"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
-              "repeatable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/coordinates",
-            "propertyLabel": "Coordinates statement"
+            "propertyLabel": "Coordinates (RDA 7.4)",
+            "remark": "http://access.rdatoolkit.org/7.4.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Projection"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/projection",
+            "propertyLabel": "Projection (RDA 7.26)",
+            "remark": "http://access.rdatoolkit.org/7.26.html"
           }
         ],
-        "id": "profile:bf2:Cartographic:Coordinates",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Cartographic",
-        "resourceLabel": "Cartographic Coordinates"
+        "id": "profile:bf2:Cartographic:Attributes",
+        "resourceLabel": "Cartographic Attributes"
       },
       {
         "propertyTemplates": [
@@ -2994,16 +3639,18 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
+              "defaults": [],
               "valueDataType": {}
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
+            "propertyLabel": "Cartographic Data Type",
+            "remark": "http://access.rdatoolkit.org/3.19.8.5.html"
           }
         ],
-        "id": "profile:bf2:Cartographic:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/CartographicDataType",
+        "id": "profile:bf2:Cartographic:DataType",
+        "remark": "",
+        "resourceLabel": "Cartographic Data Type"
       },
       {
         "propertyTemplates": [
@@ -3015,16 +3662,17 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
+              "defaults": [],
               "valueDataType": {}
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
+            "propertyLabel": "Cartographic Object Type",
+            "remark": "http://access.rdatoolkit.org/3.19.8.html"
           }
         ],
-        "id": "profile:bf2:Cartographic:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
+        "id": "profile:bf2:Cartographic:ObjectType",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/CartographicObjectType",
+        "resourceLabel": "Cartographic Object Type"
       },
       {
         "propertyTemplates": [
@@ -3038,7 +3686,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Scale"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Scale (RDA 7.25)",
@@ -3054,7 +3703,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Additional Scale Information"
@@ -3068,111 +3718,6 @@
         "propertyTemplates": [
           {
             "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:Cartographic:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/CartographicDataType",
-            "propertyLabel": "Cartographic data type"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/CartographicObjectType",
-            "propertyLabel": "Cartographic object type"
-          }
-        ],
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic",
-        "id": "profile:bf2:Cartographic:Digital",
-        "resourceLabel": "Digital characteristics"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:Cartographic:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
             "repeatable": "false",
             "type": "literal",
             "resourceTemplates": [],
@@ -3180,14 +3725,15 @@
               "valueTemplateRefs": [],
               "useValuesFrom": [],
               "valueDataType": {},
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Geographic Classification"
           }
         ],
         "id": "profile:bf2:Cartographic:Class",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Classification",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
         "resourceLabel": "Geographic Classification"
       },
       {
@@ -3208,7 +3754,8 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
               },
-              "valueTemplateRefs": []
+              "valueTemplateRefs": [],
+              "defaults": []
             }
           },
           {
@@ -3226,7 +3773,8 @@
               },
               "valueTemplateRefs": [
                 "profile:bflc:Agents:PrimaryContribution"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3242,7 +3790,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:WorkTitle"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3258,7 +3807,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Form"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3274,7 +3824,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Form:Geog"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3285,7 +3836,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
@@ -3304,7 +3856,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Cartographic:Coordinates"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3326,7 +3879,8 @@
               "repeatable": "true",
               "editable": "false",
               "defaultURI": "",
-              "defaultLiteral": ""
+              "defaultLiteral": "",
+              "defaults": []
             }
           },
           {
@@ -3342,7 +3896,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Topic"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3355,7 +3910,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work",
@@ -3372,7 +3928,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -3390,7 +3947,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:RelatedWork"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3405,7 +3963,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Cartographic:Contents"
-              ]
+              ],
+              "defaults": []
             },
             "remark": ""
           },
@@ -3422,7 +3981,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Cartographic:Expression"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3435,7 +3995,8 @@
                 "profile:bf2:Cartographic:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance",
@@ -3452,7 +4013,8 @@
               "valueDataType": {
                 "dataTypeURI": "",
                 "dataTypeLabel": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
@@ -3470,7 +4032,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 ""
-              ]
+              ],
+              "defaults": []
             }
           }
         ],
@@ -3495,7 +4058,8 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
               },
-              "valueTemplateRefs": []
+              "valueTemplateRefs": [],
+              "defaults": []
             }
           },
           {
@@ -3515,8 +4079,12 @@
               },
               "valueTemplateRefs": [],
               "editable": "true",
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/cri",
-              "defaultLiteral": "cartographic image"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/cri",
+                  "defaultLiteral": "cartographic image"
+                }
+              ]
             }
           },
           {
@@ -3527,7 +4095,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.10.html",
             "propertyLabel": "Date of Expression (RDA 6.10)",
@@ -3548,7 +4117,8 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
-              "valueTemplateRefs": []
+              "valueTemplateRefs": [],
+              "defaults": []
             }
           },
           {
@@ -3561,7 +4131,8 @@
                 "profile:bf2:Cartographic:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary",
@@ -3577,7 +4148,8 @@
                 "profile:bf2:Language:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -3591,7 +4163,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Script (RDA 7.13.2)",
@@ -3607,7 +4180,8 @@
                 "profile:bf2:Cartographic:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content",
@@ -3626,7 +4200,8 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -3642,7 +4217,8 @@
                 "profile:bf2:Cartographic:Scale"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/scale",
             "propertyLabel": "Scale information"
@@ -3655,7 +4231,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/projection",
             "propertyLabel": "Projection of Cartographic Content (RDA 7.26)",
@@ -3669,7 +4246,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/7.27.html",
             "propertyLabel": "Other Details of Cartographic Content (RDA 7.27)",
@@ -3683,7 +4261,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Time Period of Content (MARC 045 field)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage"
@@ -3701,7 +4280,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Agents:Contribution"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3717,7 +4297,8 @@
               "valueDataType": {},
               "valueTemplateRefs": [
                 "profile:bf2:Note"
-              ]
+              ],
+              "defaults": []
             }
           },
           {
@@ -3728,7 +4309,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
             "remark": "http://access.rdatoolkit.org/6.27.3.html",
@@ -3737,12 +4319,7 @@
         ],
         "resourceLabel": "BIBFRAME Work (RDA Expression Elements)",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -3782,11 +4359,167 @@
         "id": "profile:bf2:DDC",
         "resourceLabel": "Dewey Decimal Classification",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/ClassificationDdc"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/mbroadstd"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BroadcastStandard"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Broadcast Standard (RDA 3.18.3)",
+            "remark": "http://access.rdatoolkit.org/3.18.3.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Details of Broadcast Standard (RDA 3.18.3.4)",
+            "remark": "http://access.rdatoolkit.org/3.18.3.4.html"
+          }
+        ],
+        "id": "profile:bf2:BroadStd",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/BroadcastStandard",
+        "resourceLabel": "Broadcast Standard"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Capture:Place"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
+            "propertyLabel": "Place of Capture (RDA 7.11.2)",
+            "remark": "http://access.rdatoolkit.org/7.11.2.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
+            "propertyLabel": "Date of Capture (RDA 7.11.3)",
+            "remark": "http://access.rdatoolkit.org/7.11.3.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Capture note"
+          }
+        ],
+        "id": "profile:bf2:Capture",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Capture",
+        "resourceLabel": "Capture information"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/authorities/names",
+                "http://id.loc.gov/authorities/subjects"
+              ],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Search LCNAF/LCSH"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Record Place (if it does not appear above)"
+          }
+        ],
+        "id": "profile:bf2:Capture:Place",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
+        "resourceLabel": "Place of capture"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Details of Digital File Characteristic (RDA 3.19.1.4)",
+            "remark": "http://access.rdatoolkit.org/3.19.1.4.html"
+          }
+        ],
+        "id": "profile:bf2:DigChar",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic",
+        "resourceLabel": "Digital Characteristics"
+      },
       {
         "propertyTemplates": [
           {
@@ -3797,50 +4530,735 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
+              "defaults": [],
               "valueDataType": {}
             },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
-            "propertyLabel": "Edition Statement (RDA 2.5)",
-            "remark": "http://access.rdatoolkit.org/2.5.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Designation of Edition (RDA 2.5.2)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionEnumeration",
-            "remark": "http://access.rdatoolkit.org/2.5.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
-            "propertyLabel": "Statement of Responsibility Relating to the Edition (RDA 2.5.4)",
-            "remark": "http://access.rdatoolkit.org/2.5.4.html"
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Encoding Format (RDA 3.19.3)",
+            "remark": "http://access.rdatoolkit.org/3.19.3.html"
           }
         ],
-        "id": "profile:bf2:EditionInformation",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
-        "resourceLabel": "Edition (unused)",
-        "remark": "http://access.rdatoolkit.org/2.5.html"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+        "id": "profile:bf2:EncFmt",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/EncodingFormat",
+        "resourceLabel": "Encoding Format"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Extent (RDA 3.4)",
+            "remark": "http://access.rdatoolkit.org/3.4.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note on extent"
+          }
+        ],
+        "id": "profile:bf2:Extent",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
+        "resourceLabel": "Extent"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "File Size (RDA 3.19.4)",
+            "remark": "http://access.rdatoolkit.org/3.19.4.html"
+          }
+        ],
+        "id": "profile:bf2:FileSize",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileSize",
+        "resourceLabel": "File Size"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/mfiletype"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/FileType"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "File Type (RDA 3.19.2)",
+            "remark": "http://access.rdatoolkit.org/3.19.2.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Details of File Type (RDA 3.19.2.4)",
+            "remark": "http://access.rdatoolkit.org/3.19.2.4.html"
+          }
+        ],
+        "id": "profile:bf2:FileType",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileType",
+        "resourceLabel": "File Type"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/maudience"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Intended Audience (RDA 7.7)",
+            "remark": "http://access.rdatoolkit.org/7.7.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note about Audience"
+          }
+        ],
+        "id": "profile:bf2:Audience",
+        "resourceLabel": "Intended Audience",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/mplayback"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Configuration of Playback Channels (RDA 3.16.8)",
+            "remark": "http://access.rdatoolkit.org/3.16.8.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Details of Configuration of Playback Channels (RDA 3.16.8.4)",
+            "remark": "http://access.rdatoolkit.org/3.16.8.4.html"
+          }
+        ],
+        "id": "profile:bf2:Playback",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels",
+        "resourceLabel": "Playback Channels"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Playing Speed (RDA 3.16.4)",
+            "remark": "http://access.rdatoolkit.org/3.16.4.html"
+          }
+        ],
+        "id": "profile:bf2:PlayingSpeed",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlayingSpeed",
+        "resourceLabel": "Playing Speed"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/mproduction"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeLabel": "",
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Production Method (RDA 3.9.1.3)",
+            "remark": "http://access.rdatoolkit.org/3.9.1.3.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Details of Production Method (RDA 3.9.1.4)",
+            "remark": "http://access.rdatoolkit.org/3.9.1.4.html"
+          }
+        ],
+        "id": "profile:bf2:ProdMeth",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod",
+        "resourceLabel": "Production Method"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/mrecmedium"
+              ],
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mrecmedium/opt",
+                  "defaultLiteral": "optical"
+                }
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium"
+              }
+            },
+            "propertyLabel": "Recording Medium (RDA 3.16.3)",
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "remark": "http://access.rdatoolkit.org/3.16.3.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Details of Recording Medium (RDA 3.16.3.4)",
+            "remark": "http://access.rdatoolkit.org/3.16.3.4.html"
+          }
+        ],
+        "id": "profile:bf2:RecMedium",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium",
+        "resourceLabel": "Recording Medium"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/mregencoding"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/RegionalEncoding"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Regional Encoding (RDA 3.19.6.3)",
+            "remark": "http://access.rdatoolkit.org/3.19.6.3.html"
+          }
+        ],
+        "id": "profile:bf2:RegEncoding",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RegionalEncoding",
+        "resourceLabel": "Regional Encoding"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Resolution (RDA 3.19.5)",
+            "remark": "http://access.rdatoolkit.org/3.19.5.html"
+          }
+        ],
+        "id": "profile:bf2:Resolution",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Resolution",
+        "resourceLabel": "Resolution"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/msoundcontent"
+              ],
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/msoundcontent/sound",
+                  "defaultLiteral": "sound"
+                }
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SoundContent"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Sound Content (RDA 7.18)",
+            "remark": "http://access.rdatoolkit.org/7.18.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Details of Sound Content (RDA 7.18)",
+            "remark": "http://access.rdatoolkit.org/7.18.html"
+          }
+        ],
+        "id": "profile:bf2:SoundContent",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SoundContent",
+        "resourceLabel": "Sound Content"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/mspecplayback"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Special Playback Characteristic (RDA 3.16.9)",
+            "remark": "http://access.rdatoolkit.org/3.16.9.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note on Playback Characteristic"
+          }
+        ],
+        "id": "profile:bf2:SpecPlayback",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic",
+        "resourceLabel": "Special Playback Characteristic"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/mrectype"
+              ],
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mrectype/digital",
+                  "defaultLiteral": "digital"
+                }
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Type of Recording (RDA 3.16.2)",
+            "remark": "http://access.rdatoolkit.org/3.16.2.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Details of Type of Recording (RDA 3.16.2.4)",
+            "remark": "http://access.rdatoolkit.org/3.16.2.4.html"
+          }
+        ],
+        "id": "profile:bf2:TypeRec",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod",
+        "resourceLabel": "Type of Recording"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/authorities/performanceMediums"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "LCMPT for Instrument"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
+            "propertyLabel": "Number"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrumentalType",
+            "propertyLabel": "Type of instrument"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note"
+          }
+        ],
+        "id": "profile:bf2:MOPInstrument",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument",
+        "resourceLabel": "Instrument"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/authorities/performanceMediums"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "LCMPT for Voice"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
+            "propertyLabel": "Number"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/voiceType",
+            "propertyLabel": "Type of voice"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note"
+          }
+        ],
+        "id": "profile:bf2:MOPVoice",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice",
+        "resourceLabel": "Voice"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/authorities/performanceMediums"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "LCMPT for Ensemble"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
+            "propertyLabel": "Number"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensembleType",
+            "propertyLabel": "Type of Ensemble"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note"
+          }
+        ],
+        "id": "profile:bf2:MOPEnsemble",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble",
+        "resourceLabel": "Ensemble"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Medium of Performance (RDA 7.21)",
+            "remark": "http://access.rdatoolkit.org/7.21.html"
+          }
+        ],
+        "id": "profile:bf2:MOPStatement",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
+        "resourceLabel": "Medium of Performance Statement"
+      },
       {
         "propertyTemplates": [
           {
@@ -3856,17 +5274,17 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyLabel": "Search LCGFT (RDA 6.3)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "remark": "http://access.rdatoolkit.org/6.3.html"
           }
         ],
         "id": "profile:bf2:Form",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
-        "resourceLabel": "Form/Genre",
-        "contact": "NDMSO"
+        "resourceLabel": "Form/Genre"
       },
       {
         "propertyTemplates": [
@@ -3886,7 +5304,8 @@
                 "remark": ""
               },
               "repeatable": "false",
-              "remark": ""
+              "remark": "",
+              "defaults": []
             },
             "propertyLabel": "(Geographic) Coverage of the Content (RDA 7.3)",
             "remark": "http://access.rdatoolkit.org/7.3.html",
@@ -3902,7 +5321,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note about Geographic coverage"
@@ -3924,7 +5344,8 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/genreForms"
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Search LCGFT",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
@@ -3933,1236 +5354,7 @@
         "id": "profile:bf2:FormTest",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
         "resourceLabel": "Form/Genre Test"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/works"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
-            "propertyLabel": "Lookup"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bflc:Agents:PrimaryContribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "propertyLabel": "Creator of Work (RDA 19.2)",
-            "remark": "http://access.rdatoolkit.org/19.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:WorkTitle",
-                "profile:bf2:WorkVariantTitle",
-                "profile:bflc:TranscribedTitle"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
-            "propertyLabel": "Title Information"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Form"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
-            "propertyLabel": "Form of Work"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
-            "propertyLabel": "Date of Work (RDA 6.4)",
-            "remark": "http://access.rdatoolkit.org/6.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Place"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
-            "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
-            "remark": "http://access.rdatoolkit.org/6.5.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Form:Geog"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
-            "propertyLabel": "(Geographic) Coverage of the Content"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
-            "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
-            "remark": "http://access.rdatoolkit.org/7.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:Audience"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
-            "propertyLabel": "Intended Audience"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Agents:Contribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
-            "remark": "http://access.rdatoolkit.org/19.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:TopicSearch",
-                "profile:bf2:Components",
-                "profile:bf2:TopicInput"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
-            "propertyLabel": "Subject of the Work (RDA Chapter 23)",
-            "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Notes about the Work"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:Dissertation"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/dissertation",
-            "propertyLabel": "Dissertation (RDA 7.9)",
-            "remark": "http://access.rdatoolkit.org/7.9.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:Contents"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
-            "propertyLabel": "Contents (LC-PCC PS 25.1)"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:Summary"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
-            "propertyLabel": "Summary"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:LCC",
-                "profile:bf2:DDC"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
-            "propertyLabel": "Classification numbers"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/contentTypes"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
-              "defaultLiteral": "text",
-              "editable": "false",
-              "repeatable": "true"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
-            "propertyLabel": "Content Type (RDA 6.9)",
-            "remark": "http://access.rdatoolkit.org/6.9.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Language2"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              },
-              "editable": "false",
-              "repeatable": "true"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
-            "propertyLabel": "Language",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Script"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
-            "propertyLabel": "Script (RDA 7.13.2)",
-            "remark": "http://access.rdatoolkit.org/7.13.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/millus"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
-              },
-              "repeatable": "true",
-              "editable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
-            "propertyLabel": "Illustrative Content (RDA 7.15)",
-            "remark": "http://access.rdatoolkit.org/7.15.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:SupplContent"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-            "propertyLabel": "Supplementary Content"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
-            "propertyLabel": "Color Content (RDA 7.17)",
-            "remark": "http://access.rdatoolkit.org/7.17.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RelatedWork"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RelatedExpression"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
-          }
-        ],
-        "id": "profile:bf2:IBC:Work",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
-        "resourceLabel": "BIBFRAME Work"
       },
-      {
-        "id": "profile:bf2:IBC:Instance",
-        "propertyTemplates": [
-          {
-            "propertyLabel": "Instance of",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:Work"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true"
-          },
-          {
-            "propertyLabel": "Title Information",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Title",
-                "profile:bf2:Title:VarTitle",
-                "profile:bf2:ParallelTitle",
-                "profile:bflc:TranscribedTitle"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "remark": ""
-              }
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
-            "remark": "http://access.rdatoolkit.org/2.4.2.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
-          },
-          {
-            "propertyLabel": "Edition Statement (RDA 2.5)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "remark": "http://access.rdatoolkit.org/2.5.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:PublicationInformation",
-                "profile:bf2:DistributionInformation",
-                "profile:bf2:ManufactureInformation"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
-            "propertyLabel": "Publication, Distribution, Manufacture Statements",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
-            "propertyLabel": "Copyright Date (RDA 2.11)",
-            "remark": "http://access.rdatoolkit.org/2.11.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SeriesInformation"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeLabelHint": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
-            "propertyLabel": "Series Statement",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/issuance"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit",
-              "editable": "false",
-              "repeatable": "true"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
-            "propertyLabel": "Mode of Issuance (RDA 2.13)",
-            "remark": "http://access.rdatoolkit.org/2.13.html"
-          },
-          {
-            "propertyLabel": "Identifier for the Manifestation",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:ISBN",
-                "profile:bf2:Identifiers:Other",
-                "profile:bf2:Identifiers:Local"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Notes about the Instance",
-            "remark": "http://access.rdatoolkit.org/2.17.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          },
-          {
-            "propertyLabel": "Media type (RDA 3.2)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
-            "repeatable": "true",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mediaTypes"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
-              "defaultLiteral": "unmediated",
-              "editable": "false",
-              "repeatable": "true"
-            },
-            "mandatory": "false",
-            "remark": "http://access.rdatoolkit.org/3.2.html"
-          },
-          {
-            "propertyLabel": "Extent",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:Extent"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "remark": ""
-          },
-          {
-            "propertyLabel": "Dimensions (RDA 3.5)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "remark": "http://access.rdatoolkit.org/3.5.html"
-          },
-          {
-            "propertyLabel": "Carrier Type (RDA 3.3)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
-            "repeatable": "true",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/carriers"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
-              "defaultLiteral": "volume",
-              "repeatable": "true",
-              "editable": "false"
-            },
-            "mandatory": "false",
-            "remark": "http://access.rdatoolkit.org/3.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:RelatedInstance"
-              ],
-              "useValuesFrom": [
-                ""
-              ],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
-            "propertyLabel": "Related Manifestation",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:IBC:Item"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeLabelHint": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
-            "propertyLabel": "Has Item",
-            "remark": "Item which is an example of the described Instance."
-          },
-          {
-            "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
-            "resourceTemplates": [],
-            "type": "literal",
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "remark": "http://access.rdatoolkit.org/4.6.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:LCCN"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
-            "remark": "http://access.rdatoolkit.org/2.15.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:AdminMetadata"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
-            "propertyLabel": "Administrative Metadata for Instance"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/projectedProvisionDate",
-            "propertyLabel": "Projected publication date (YYMM)",
-            "remark": "http://id.loc.gov/ontologies/bflc.html#p_projectedProvisionDate"
-          }
-        ],
-        "resourceLabel": "BIBFRAME Instance",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
-        "remark": ""
-      },
-      {
-        "id": "profile:bf2:IBC:Item",
-        "propertyTemplates": [
-          {
-            "propertyLabel": "Held by",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
-            "resourceTemplates": [],
-            "type": "literal",
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
-            },
-            "mandatory": "false",
-            "repeatable": "true"
-          },
-          {
-            "propertyLabel": "Shelving call numbers",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:LC"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource"
-          },
-          {
-            "propertyLabel": "Electronic location",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal"
-          },
-          {
-            "propertyLabel": "Held in sublocation",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal"
-          },
-          {
-            "propertyLabel": "Barcode",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:Barcode"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource"
-          },
-          {
-            "propertyLabel": "Notes about the Item",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource"
-          },
-          {
-            "propertyLabel": "Lending, Reproduction, and Retention Policies",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Item:Access",
-                "profile:bf2:Item:Use",
-                "profile:bf2:Item:Retention"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Item:Enumeration",
-                "profile:bf2:Item:Chronology"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Enumeration And Chronology of Item",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "http://access.rdatoolkit.org/2.18.html",
-            "propertyLabel": "Custodial History of Item (RDA 2.18)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/custodialHistory"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Item:ImmAcqSource"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
-            "propertyLabel": "Immediate Source of Acquisition of Item",
-            "remark": ""
-          }
-        ],
-        "resourceLabel": "BIBFRAME Item",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Item"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
-            "propertyLabel": "Related Manifestations (RDA 27)",
-            "remark": "http://access.rdatoolkit.org/27.1.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Also issued in another format as:",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
-            "remark": "http://access.rdatoolkit.org/J.4.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy",
-            "propertyLabel": "Accompanied by (manifestation):",
-            "remark": "http://access.rdatoolkit.org/J.4.5.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Reprinted as (manifestation):",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
-            "remark": "http://access.rdatoolkit.org/J.4.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "http://access.rdatoolkit.org/J.4.2.html",
-            "propertyLabel": "Reprint of (manifestation)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Record Relationship Designator for Related Manifestation (RDA Appendix J)",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/relationshipTarget",
-            "remark": "http://access.rdatoolkit.org/J.4.html"
-          }
-        ],
-        "id": "profile:bf2:IBC:RelatedInstance",
-        "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
-        "resourceLabel": "Related Manifestation"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "id": "profile:bf2:IBC:Contents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
-          }
-        ],
-        "id": "profile:bf2:IBC:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "lookup",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/maudience"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              },
-              "editable": "true",
-              "repeatable": "true"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Intended Audience (RDA 7.7)",
-            "remark": "http://access.rdatoolkit.org/7.7.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note about Audience",
-            "remark": ""
-          }
-        ],
-        "id": "profile:bf2:IBC:Audience",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience",
-        "resourceLabel": "Intended Audience"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/degree",
-            "propertyLabel": "Degree"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                ""
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/grantingInstitution",
-            "propertyLabel": "Institution"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
-            "propertyLabel": "Date"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Dissertation note"
-          }
-        ],
-        "id": "profile:bf2:IBC:Dissertation",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Dissertation",
-        "resourceLabel": "Dissertation"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:IBC:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html",
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:IBC:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
       {
         "propertyTemplates": [
           {
@@ -5175,7 +5367,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Barcode",
             "propertyLabel": "Barcode"
@@ -5190,7 +5383,8 @@
                 "profile:bf2:Identifiers:Copyright"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/CopyrightRegistration",
             "propertyLabel": "Copyright Registration Number"
@@ -5205,7 +5399,8 @@
                 "profile:bf2:Identifiers:EAN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "EAN",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Ean"
@@ -5220,7 +5415,8 @@
                 "profile:bf2:Identifiers:Eidr"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/Eidr",
             "propertyLabel": "EIDR"
@@ -5235,7 +5431,8 @@
                 "profile:bf2:Identifiers:ISBN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Isbn",
             "propertyLabel": "ISBN"
@@ -5250,7 +5447,8 @@
                 "profile:bf2:Identifiers:ISMN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Ismn",
             "propertyLabel": "ISMN"
@@ -5265,7 +5463,8 @@
                 "profile:bf2:TestProfile:ISRC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Isrc",
             "propertyLabel": "ISRC"
@@ -5280,7 +5479,8 @@
                 "profile:bf2:Identifiers:ISSN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Issn",
             "propertyLabel": "ISSN"
@@ -5295,7 +5495,8 @@
                 "profile:bf2:Identifiers:ISSNL"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/IssnL",
             "propertyLabel": "ISSN-L"
@@ -5310,7 +5511,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "LCCN",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Lccn"
@@ -5325,7 +5527,8 @@
                 "profile:bf2:Identifiers:Distributor"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/StockNumber",
             "propertyLabel": "Music Distributor Number"
@@ -5340,7 +5543,8 @@
                 "profile:bf2:Identifiers:MusicPlate"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/MusicPlate",
             "propertyLabel": "Music Plate Number"
@@ -5355,7 +5559,8 @@
                 "profile:bf2:Identifiers:MusicPub"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/MusicPublisherNumber",
             "propertyLabel": "Music Publisher Number"
@@ -5370,7 +5575,8 @@
                 "profile:bf2:Identifiers:PubNumber"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/PublisherNumber",
             "propertyLabel": "Publisher Number"
@@ -5385,7 +5591,8 @@
                 "profile:bf2:Identifiers:STRN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Strn",
             "propertyLabel": "Standard Technical Report Number"
@@ -5400,7 +5607,8 @@
                 "profile:bf2:Identifiers:UPC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Upc",
             "propertyLabel": "Universal Product Code (UPC)"
@@ -5414,13 +5622,81 @@
         "propertyTemplates": [
           {
             "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+            "propertyLabel": "Audio Issue Number"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Identifiers:Source"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
+            "propertyLabel": "Source of Number"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
+            "propertyLabel": "Qualifier"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note on Audio Issue Number"
+          }
+        ],
+        "id": "profile:bf2:Identifiers:AudioIssue",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/AudioIssueNumber",
+        "resourceLabel": "Audio Issue Number"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
             "repeatable": "false",
             "type": "literal",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Barcode"
@@ -5440,7 +5716,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Copyright Registration Number",
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
@@ -5456,7 +5733,8 @@
                 "profile:bf2:Identifiers:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Assigning agency"
@@ -5471,7 +5749,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on Copyright Registration"
@@ -5491,7 +5770,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "EAN",
@@ -5505,7 +5785,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -5520,7 +5801,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on EAN"
@@ -5540,7 +5822,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "EIDR"
@@ -5555,7 +5838,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on EIDR"
@@ -5575,7 +5859,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "GTIN-14 number"
@@ -5590,7 +5875,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note about GTIN-14"
@@ -5611,7 +5897,8 @@
               "valueTemplateRefs": [],
               "useValuesFrom": [],
               "valueDataType": {},
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "ISBN (RDA 2.15)",
@@ -5625,7 +5912,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -5640,7 +5928,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on ISBN"
@@ -5657,7 +5946,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
             "propertyLabel": "Incorrect, Invalid or Canceled?"
@@ -5677,7 +5967,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "ISMN",
@@ -5691,7 +5982,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -5706,7 +5998,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on ISMN"
@@ -5726,7 +6019,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "ISRC",
@@ -5740,7 +6034,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -5755,13 +6050,14 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on ISRC"
           }
         ],
-        "id": "profile:bf2:TestProfile:ISRC",
+        "id": "profile:bf2:Identifiers:ISRC",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Isrc",
         "resourceLabel": "ISRC"
       },
@@ -5775,7 +6071,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "ISSN",
@@ -5791,7 +6088,8 @@
                 "profile:bf2:Identifiers:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Assigning agency"
@@ -5806,7 +6104,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on ISSN"
@@ -5823,7 +6122,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
             "propertyLabel": "Incorrect, Invalid or Canceled?"
@@ -5843,7 +6143,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "ISSN-L",
@@ -5859,7 +6160,8 @@
                 "profile:bf2:Identifiers:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Assigning agency"
@@ -5874,7 +6176,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on ISSN-L"
@@ -5891,7 +6194,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
             "propertyLabel": "Incorrect, Invalid or Canceled?"
@@ -5911,7 +6215,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "LCCN",
@@ -5929,7 +6234,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/status",
             "propertyLabel": "Invalid/Canceled?"
@@ -5949,7 +6255,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Local system number"
@@ -5964,7 +6271,8 @@
                 "profile:bf2:Identifiers:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Source of number (e.g. OCLC)"
@@ -5979,7 +6287,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on local system number"
@@ -5999,7 +6308,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Matrix Number"
@@ -6012,7 +6322,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -6027,7 +6338,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on Matrix Number"
@@ -6047,7 +6359,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Music Distributor Number",
@@ -6063,7 +6376,8 @@
                 "profile:bf2:Identifiers:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Source of Number",
@@ -6077,7 +6391,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -6092,7 +6407,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note"
@@ -6112,7 +6428,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Music Plate Number",
@@ -6128,7 +6445,8 @@
                 "profile:bf2:Identifiers:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Publisher Name"
@@ -6141,7 +6459,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -6156,7 +6475,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on Music Plate Number"
@@ -6176,7 +6496,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Music Publisher Number",
@@ -6192,7 +6513,8 @@
                 "profile:bf2:Identifiers:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Label name"
@@ -6205,7 +6527,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -6220,7 +6543,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on Music Publisher Number"
@@ -6240,7 +6564,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Other identifier",
@@ -6254,7 +6579,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -6269,7 +6595,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on other identifier"
@@ -6289,7 +6616,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Publisher Number",
@@ -6305,7 +6633,8 @@
                 "profile:bf2:Identifiers:Source"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Label name"
@@ -6318,7 +6647,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -6333,7 +6663,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on Publisher Number"
@@ -6353,7 +6684,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Standard Technical Report Number",
@@ -6367,7 +6699,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -6382,7 +6715,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on STRN"
@@ -6402,7 +6736,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Universal Product Code (UPC)",
@@ -6416,7 +6751,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier",
             "propertyLabel": "Qualifier"
@@ -6431,7 +6767,8 @@
                 "profile:bf2:Identifiers:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on Universal Product Code (UPC)"
@@ -6451,7 +6788,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Note text",
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
@@ -6471,7 +6809,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Label name"
@@ -6491,14 +6830,15 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "LC shelfmark"
           }
         ],
         "id": "profile:bf2:Identifiers:LC",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/ShelfmarkLcc",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/ShelfMarkLcc",
         "resourceLabel": "LC shelfmark"
       },
       {
@@ -6511,7 +6851,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "DDC shelfmark"
@@ -6531,7 +6872,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Accession or copy number"
@@ -6540,11 +6882,7 @@
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/ShelfMark",
         "id": "profile:bf2:Identifiers:Shelfmark",
         "resourceLabel": "Accession or copy number"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -6806,12 +7144,7 @@
         "id": "profile:bf2:Item:Chronology",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Chronology",
         "resourceLabel": "Chronology"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -6831,11 +7164,7 @@
         "id": "profile:bf2:LCC",
         "resourceLabel": "Library of Congress Classification",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/ClassificationLcc"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -6849,13 +7178,14 @@
                 "http://id.loc.gov/vocabulary/languages"
               ],
               "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/Language"
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language",
+                "remark": ""
               },
               "valueLanguage": "",
               "remark": "",
               "editable": "true",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -6871,7 +7201,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -6895,7 +7226,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Language of Content"
@@ -6904,125 +7236,7 @@
         "id": "profile:bf2:Language:Note",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Language",
         "resourceLabel": "Language of Content"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bflc:Agents:PrimaryContribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "propertyLabel": "Creator of Work (RDA 19.2)",
-            "remark": "http://access.rdatoolkit.org/19.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:WorkTitle",
-                "profile:bf2:WorkVariantTitle",
-                "profile:bflc:TranscribedTitle"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
-            "propertyLabel": "Title Information"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Agents:bfContribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "propertyLabel": "Other Agent Associated with Work (RDA 19.3)",
-            "remark": "http://access.rdatoolkit.org/19.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:TopicSearch",
-                "profile:bf2:Components",
-                "profile:bf2:TopicInput"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
-            "propertyLabel": "Subject of the Work (RDA Chapter 23)",
-            "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:LCCN"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "propertyLabel": "LC Control Number for the Work",
-            "remark": "http://access.rdatoolkit.org/2.15.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:AdminMetadata"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
-            "propertyLabel": "Administrative Metadata for Loaded Work"
-          }
-        ],
-        "id": "profile:bf2:Load:Work",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
-        "resourceLabel": "BIBFRAME Work for Loading"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -7037,7 +7251,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Lookup"
@@ -7054,7 +7269,10 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false",
+              "repeatable": "true"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -7072,7 +7290,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information"
@@ -7087,7 +7306,14 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+                "dataTypeLabel": "Series enumeration",
+                "remark": ""
+              },
+              "defaults": [],
+              "editable": "false",
+              "repeatable": "true"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -7100,7 +7326,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Work (RDA 6.4)",
@@ -7116,7 +7343,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
             "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
@@ -7132,7 +7360,9 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
             "propertyLabel": "(Geographic) Coverage of the Content"
@@ -7145,7 +7375,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
@@ -7158,10 +7389,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Monograph:Audience"
+                "profile:bf2:Audience"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience"
@@ -7178,7 +7410,10 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false",
+              "repeatable": "true"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -7196,7 +7431,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -7212,7 +7448,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -7227,7 +7464,8 @@
                 "profile:bf2:Monograph:Dissertation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/dissertation",
             "propertyLabel": "Dissertation (RDA 7.9)",
@@ -7240,10 +7478,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Monograph:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -7255,10 +7494,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Monograph:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -7274,7 +7514,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -7292,10 +7533,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
-              "defaultLiteral": "text",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                  "defaultLiteral": "text"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -7315,7 +7560,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -7331,7 +7577,8 @@
                 "profile:bf2:Script"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Script (RDA 7.13.2)",
@@ -7351,7 +7598,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
               },
               "repeatable": "true",
-              "editable": "false"
+              "editable": "false",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content (RDA 7.15)",
@@ -7364,25 +7612,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Monograph:SupplContent"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-            "propertyLabel": "Supplementary Content"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -7395,10 +7629,27 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
+                "profile:bf2:SupplContent"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+            "propertyLabel": "Supplementary Content"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
             "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
@@ -7414,7 +7665,8 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
             "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
@@ -7430,7 +7682,8 @@
                 "profile:bf2:Monograph:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -7443,7 +7696,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
@@ -7467,7 +7721,8 @@
                 "profile:bf2:Monograph:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -7486,7 +7741,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7501,7 +7757,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
             "remark": "http://access.rdatoolkit.org/2.4.2.html",
@@ -7514,7 +7771,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7533,7 +7791,8 @@
                 "profile:bf2:ManufactureInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
             "propertyLabel": "Publication, Distribution, Manufacture Statements",
@@ -7547,7 +7806,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -7565,7 +7825,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabelHint": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
             "propertyLabel": "Series Statement",
@@ -7584,10 +7845,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -7605,7 +7870,8 @@
                 "profile:bf2:Identifiers:Local"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7621,7 +7887,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Instance",
             "remark": "http://access.rdatoolkit.org/2.17.html",
@@ -7641,10 +7908,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
-              "defaultLiteral": "unmediated",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                  "defaultLiteral": "unmediated"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.2.html"
@@ -7655,10 +7926,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Monograph:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7672,7 +7944,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7693,10 +7966,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
-              "defaultLiteral": "volume",
               "repeatable": "true",
-              "editable": "false"
+              "editable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                  "defaultLiteral": "volume"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.3.html"
@@ -7711,7 +7988,8 @@
                 "profile:bf2:Monograph:RelatedInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
             "propertyLabel": "Related Manifestation",
@@ -7729,7 +8007,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabelHint": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
             "propertyLabel": "Has Item",
@@ -7743,7 +8022,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7759,7 +8039,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
@@ -7775,7 +8056,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
             "propertyLabel": "Administrative Metadata for Instance"
@@ -7788,7 +8070,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/projectedProvisionDate",
             "propertyLabel": "Projected publication date (YYMM)",
@@ -7813,8 +8096,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -7828,7 +8115,8 @@
                 "profile:bf2:Identifiers:LC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7841,7 +8129,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7854,7 +8143,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7869,7 +8159,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7884,7 +8175,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7901,7 +8193,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -7918,7 +8211,8 @@
                 "profile:bf2:Item:Chronology"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Enumeration And Chronology of Item",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology"
@@ -7931,7 +8225,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/2.18.html",
             "propertyLabel": "Custodial History of Item (RDA 2.18)",
@@ -7947,7 +8242,8 @@
                 "profile:bf2:Item:ImmAcqSource"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
             "propertyLabel": "Immediate Source of Acquisition of Item",
@@ -7967,7 +8263,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Related Manifestations (RDA 27)",
@@ -7981,7 +8278,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Also issued in another format as:",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
@@ -7995,7 +8293,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy",
             "propertyLabel": "Accompanied by (manifestation):",
@@ -8009,7 +8308,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Reprinted as (manifestation):",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
@@ -8023,7 +8323,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/J.4.2.html",
             "propertyLabel": "Reprint of (manifestation)",
@@ -8037,7 +8338,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Record Relationship Designator for Related Manifestation (RDA Appendix J)",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
@@ -8058,92 +8360,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "id": "profile:bf2:Monograph:Contents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
-          }
-        ],
-        "id": "profile:bf2:Monograph:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/maudience"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              },
-              "editable": "true",
-              "repeatable": "true"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Intended Audience (RDA 7.7)",
-            "remark": "http://access.rdatoolkit.org/7.7.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note about Audience",
-            "remark": ""
-          }
-        ],
-        "id": "profile:bf2:Monograph:Audience",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience",
-        "resourceLabel": "Intended Audience"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/degree",
             "propertyLabel": "Degree"
@@ -8160,7 +8378,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/grantingInstitution",
             "propertyLabel": "Institution"
@@ -8173,7 +8392,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
             "propertyLabel": "Date"
@@ -8188,7 +8408,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Dissertation note"
@@ -8203,418 +8424,6 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:Monograph:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html",
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:Monograph:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      },
-      {
-        "id": "profile:bf2:Monograph:WorkOld",
-        "propertyTemplates": [
-          {
-            "propertyLabel": "Lookup",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/works"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
-            },
-            "mandatory": "false",
-            "repeatable": "true"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bflc:Agents:PrimaryContribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
-            },
-            "propertyLabel": "Creator of Work (RDA 19.2)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "remark": "http://access.rdatoolkit.org/19.2.html"
-          },
-          {
-            "propertyLabel": "Title Information",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
-            "remark": "",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:WorkTitle",
-                "profile:bf2:WorkVariantTitle",
-                "profile:bflc:TranscribedTitle"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource"
-          },
-          {
-            "propertyLabel": "Form of Work",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Form"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "",
-            "mandatory": "false",
-            "repeatable": "true"
-          },
-          {
-            "propertyLabel": "Date of Work (RDA 6.4)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "http://access.rdatoolkit.org/6.4.html",
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal"
-          },
-          {
-            "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Place"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "http://access.rdatoolkit.org/6.5.html",
-            "mandatory": "false",
-            "repeatable": "true"
-          },
-          {
-            "propertyLabel": "(Geographic) Coverage of the Content",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Form:Geog"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "",
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
-            "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
-            "remark": "http://access.rdatoolkit.org/7.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Monograph:Audience"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
-            "propertyLabel": "Intended Audience",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Agents:Contribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
-              }
-            },
-            "propertyLabel": "Other Agent Associated with Work (RDA 19.3)",
-            "remark": "http://access.rdatoolkit.org/19.3.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
-          },
-          {
-            "propertyLabel": "Subject of the Work (RDA Chapter 23)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Topic"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
-            "mandatory": "false",
-            "repeatable": "true"
-          },
-          {
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Notes about the Work",
-            "remark": "",
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Monograph:Dissertation"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/dissertation",
-            "propertyLabel": "Dissertation (RDA 7.9)",
-            "remark": "http://access.rdatoolkit.org/7.9.html"
-          },
-          {
-            "propertyLabel": "Contents (LC-PCC PS 25.1)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Monograph:Contents"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:LCC",
-                "profile:bf2:DDC"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Classification numbers",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
-          },
-          {
-            "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
-            "resourceTemplates": [],
-            "type": "resource",
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RelatedWork"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
-            "mandatory": "false",
-            "repeatable": "true"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RelatedExpression"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Monograph:Expression"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Expression elements"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Monograph:Instance"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
-            "propertyLabel": "Has BIBFRAME Instance"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "remark": "http://access.rdatoolkit.org/6.27.1.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
-            "propertyLabel": "Your Windows ID and Comments"
-          }
-        ],
-        "resourceLabel": "BIBFRAME Work (RDA Work Elements)",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
@@ -8624,7 +8433,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Expression of",
@@ -8640,7 +8450,8 @@
                 "profile:bf2:WorkTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information"
@@ -8659,8 +8470,12 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
               "editable": "true",
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
-              "defaultLiteral": "text"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                  "defaultLiteral": "text"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -8674,7 +8489,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Expression (RDA 6.10)",
@@ -8692,7 +8508,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -8708,7 +8525,8 @@
                 "profile:bf2:Monograph:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Summary",
             "remark": "",
@@ -8726,7 +8544,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -8740,7 +8559,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Script (RDA 7.13.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
@@ -8758,7 +8578,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content (RDA 7.15)",
@@ -8774,7 +8595,8 @@
                 "profile:bf2:Monograph:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content",
@@ -8792,7 +8614,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Color Content (RDA 7.17)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
@@ -8808,7 +8631,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "remark": "http://access.rdatoolkit.org/20.2.html",
@@ -8824,7 +8648,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Expression",
@@ -8838,7 +8663,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
@@ -8848,12 +8674,7 @@
         "id": "profile:bf2:Monograph:ExpressionOld",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
         "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -8868,7 +8689,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Search works"
@@ -8885,7 +8707,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information"
@@ -8900,7 +8723,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
             "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
@@ -8914,7 +8738,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Work (RDA 6.4)",
@@ -8928,7 +8753,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/historyOfWork",
             "propertyLabel": "History of the Work (RDA 6.7)",
@@ -8937,16 +8763,19 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "literal",
+            "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
-              "valueTemplateRefs": [],
+              "valueTemplateRefs": [
+                "profile:bf2:SourceConsulted"
+              ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
-            "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
-            "remark": "http://access.rdatoolkit.org/5.8.1.3.html"
+            "propertyLabel": "Source Consulted",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -8958,7 +8787,9 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "true"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
             "propertyLabel": "(Geographic) Coverage of the Content"
@@ -8971,7 +8802,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
@@ -8987,7 +8819,8 @@
                 "profile:bf2:Identifiers:Eidr"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Identifiers"
@@ -8999,10 +8832,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:Audience"
+                "profile:bf2:Audience"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience"
@@ -9017,7 +8851,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -9029,10 +8864,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -9047,7 +8883,8 @@
                 "profile:bf2:35mmFeatureFilm:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -9062,7 +8899,8 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -9079,7 +8917,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -9095,7 +8934,9 @@
                 "profile:bflc:Agents:PrimaryContribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -9111,7 +8952,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -9130,10 +8973,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
-              "defaultLiteral": "two-dimensional moving image",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
+                  "defaultLiteral": "two-dimensional moving image"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -9153,7 +9000,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -9169,7 +9017,8 @@
                 "profile:bf2:35mmFeatureFilm:Color"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content"
@@ -9181,10 +9030,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:SoundContent"
+                "profile:bf2:SoundContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundContent",
             "propertyLabel": "Sound Content"
@@ -9197,7 +9047,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -9210,12 +9061,13 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:Capture"
+                "profile:bf2:Capture"
               ],
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabel": "Place of capture:"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
             "propertyLabel": "Capture information"
@@ -9230,7 +9082,8 @@
                 "profile:bf2:35mmFeatureFilm:Event"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/eventContentOf",
             "propertyLabel": "Event"
@@ -9243,7 +9096,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/awards",
             "propertyLabel": "Award (RDA 7.28)",
@@ -9259,11 +9113,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -9275,11 +9130,12 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
+            "propertyLabel": "Related Expressions",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -9288,13 +9144,14 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:RelatedInstance"
+                "profile:bf2:RelatedInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Manifestations (RDA Chapter 27, Appendix J)"
+            "propertyLabel": "Related Instances"
           },
           {
             "mandatory": "false",
@@ -9304,7 +9161,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
@@ -9320,7 +9178,8 @@
                 "profile:bf2:35mmFeatureFilm:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -9342,7 +9201,8 @@
                 "profile:bf2:35mmFeatureFilm:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "resourceTemplates": [],
             "mandatory": "false",
@@ -9359,7 +9219,8 @@
                 "profile:bf2:ParallelTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9374,7 +9235,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
             "remark": "http://access.rdatoolkit.org/2.4.2.html",
@@ -9389,7 +9251,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9408,7 +9271,8 @@
                 "profile:bf2:ManufactureInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
             "propertyLabel": "Publication, Distribution, Manufacture Statements",
@@ -9422,7 +9286,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -9442,8 +9307,12 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
               "editable": "true",
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -9461,7 +9330,8 @@
                 "profile:bf2:Identifiers:Local"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Identifiers",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
@@ -9477,7 +9347,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Instance",
             "remark": "http://access.rdatoolkit.org/2.17.html",
@@ -9493,7 +9364,8 @@
                 "profile:bf2:35mmFeatureFilm:Credits"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Cast/Credits",
             "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
@@ -9513,10 +9385,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/g",
-              "defaultLiteral": "projected",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/g",
+                  "defaultLiteral": "projected"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.2.html"
@@ -9535,10 +9411,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/mr",
-              "defaultLiteral": "film reel",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/mr",
+                  "defaultLiteral": "film reel"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.3.html"
@@ -9549,10 +9429,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9566,7 +9447,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9581,7 +9463,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -9599,7 +9482,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
             "propertyLabel": "Base Material (RDA 3.6)",
@@ -9617,7 +9501,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Generation"
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/3.10.html",
             "propertyLabel": "Recording Generation (RDA 3.10)",
@@ -9635,7 +9520,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Polarity"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Polarity (RDA 3.14.1.3)",
             "remark": "http://access.rdatoolkit.org/3.14.1.3.html",
@@ -9648,13 +9534,14 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:Sound3",
-                "profile:bf2:35mmFeatureFilm:Sound4",
-                "profile:bf2:35mmFeatureFilm:Sound1",
-                "profile:bf2:35mmFeatureFilm:Sound2"
+                "profile:bf2:TypeRec",
+                "profile:bf2:RecMedium",
+                "profile:bf2:Playback",
+                "profile:bf2:SpecPlayback"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Sound Characteristic (RDA 3.16)",
             "remark": "http://access.rdatoolkit.org/3.16.html",
@@ -9670,7 +9557,8 @@
                 "profile:bf2:35mmFeatureFilm:ProjChar"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Projection Characteristics",
             "remark": "",
@@ -9684,7 +9572,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9700,7 +9589,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyLabel": "Persons, Families, Corporate Bodies Associated with the Manifestation (RDA 21.1.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -9713,10 +9604,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:Source"
+                "profile:bf2:SourceConsulted"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Source Consulted",
@@ -9732,7 +9624,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
@@ -9748,7 +9641,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Administrative Metadata for Instance",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
@@ -9763,7 +9657,8 @@
                 "profile:bf2:35mmFeatureFilm:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Has Item",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem"
@@ -9786,8 +9681,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -9802,7 +9701,8 @@
                 "profile:bf2:Identifiers:Shelfmark"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9817,7 +9717,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9830,7 +9731,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9844,7 +9746,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/collection",
             "propertyLabel": "Collection"
@@ -9856,7 +9759,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9871,7 +9775,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9888,7 +9793,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -9904,7 +9810,8 @@
                 "profile:bf2:Item:Enumeration"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology",
             "propertyLabel": "Enumeration"
@@ -9919,7 +9826,8 @@
                 "profile:bf2:Item:ImmAcqSource"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
             "propertyLabel": "Immediate Source of Acquisition of Item"
@@ -9933,83 +9841,13 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/instances"
-              ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Search"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "literal",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Record Related Manifestation Authorized Access Point"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Record Relationship Designator for Related Manifestation (RDA Appendix J)",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/relation"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:RelatedInstance",
-        "resourceLabel": "Related Instance",
-        "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Summary",
@@ -10025,7 +9863,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Details of Summary note"
@@ -10045,7 +9884,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Cast/credits note"
@@ -10054,80 +9894,6 @@
         "id": "profile:bf2:35mmFeatureFilm:Credits",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits",
         "resourceLabel": "Cast/Credits note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:35mmFeatureFilm:Place"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
-            "propertyLabel": "Place of Capture (RDA 7.11.2)",
-            "remark": "http://access.rdatoolkit.org/7.11.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
-            "propertyLabel": "Date of Capture (RDA 7.11.3)",
-            "remark": "http://access.rdatoolkit.org/7.11.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Capture note"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Capture",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Capture",
-        "resourceLabel": "Capture information"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Place"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Place",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
-        "resourceLabel": "Place"
       },
       {
         "propertyTemplates": [
@@ -10143,7 +9909,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ColorContent"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -10159,7 +9926,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Details of Color Content (RDA 7.17.1.4)",
@@ -10175,316 +9943,13 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/maudience"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Audience"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note about Audience"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Audience",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience",
-        "resourceLabel": "Intended Audience"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "literal",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/msoundcontent"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/SoundContent"
-              }
-            },
-            "propertyLabel": "Sound Content (RDA 7.18)",
-            "remark": "http://access.rdatoolkit.org/7.18.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Sound Content (RDA 7.18)",
-            "remark": "http://access.rdatoolkit.org/7.18.html"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:SoundContent",
-        "resourceLabel": "Sound content",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SoundContent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "dataTypeLabelHint": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic"
-              }
-            },
-            "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
-            "propertyLabel": "Projection Characteristics of Motion Picture Film (RDA 3.17)",
-            "remark": "http://access.rdatoolkit.org/3.17.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Projection Characteristics of Motion Picture Film (RDA 3.17.2.4)",
-            "remark": "http://access.rdatoolkit.org/3.17.2.4.html"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:ProjChar",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic",
-        "resourceLabel": "Projection characteristics"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrectype"
-              ],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Type of Recording (RDA 3.16.2)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Type of Recording (RDA 3.16.2.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.4.html"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Sound3",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod",
-        "resourceLabel": "Type of Recording"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrecmedium"
-              ],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Type of Recording (RDA 3.16.3)",
-            "remark": "Type of Recording (RDA 3.16.3)"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Recording Medium (RDA 3.16.3.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.4.html"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Sound4",
-        "resourceLabel": "Recording Medium",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Configuration of Playback Channels (RDA 3.16.8)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Configuration of Playback Channels (RDA 3.16.8.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.4.html"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Sound1",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels",
-        "resourceLabel": "Playback Channels"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mspecplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Special Playback Characteristic (RDA 3.16.9)",
-            "remark": "http://access.rdatoolkit.org/3.16.9.html"
-          }
-        ],
-        "id": "profile:bf2:35mmFeatureFilm:Sound2",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic",
-        "resourceLabel": "Special Playback Characteristic"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Event"
@@ -10497,7 +9962,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
             "propertyLabel": "Date of Event"
@@ -10506,27 +9972,6 @@
         "id": "profile:bf2:35mmFeatureFilm:Event",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Event",
         "resourceLabel": "Event"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
-            "remark": "http://access.rdatoolkit.org/5.8.1.3.html"
-          }
-        ],
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Source",
-        "resourceLabel": "Source Consulted",
-        "id": "profile:bf2:35mmFeatureFilm:Source"
       },
       {
         "id": "profile:bf2:35mmFeatureFilm:WorkOld",
@@ -10544,7 +9989,8 @@
               "valueTemplateRefs": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -10561,7 +10007,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -10577,7 +10024,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.5.html",
             "mandatory": "false",
@@ -10590,7 +10038,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.4.html",
             "mandatory": "false",
@@ -10605,7 +10054,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "History of the Work (RDA 6.7)",
             "remark": "http://access.rdatoolkit.org/6.7.html",
@@ -10619,7 +10069,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
@@ -10634,7 +10085,8 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -10649,7 +10101,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
@@ -10665,7 +10118,8 @@
                 "profile:bf2:Identifiers:Eidr"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Identifiers",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy"
@@ -10680,7 +10134,8 @@
                 "profile:bf2:35mmFeatureFilm:Audience"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience"
@@ -10692,7 +10147,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work",
@@ -10710,7 +10166,8 @@
                 "profile:bf2:35mmFeatureFilm:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -10727,7 +10184,8 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -10743,7 +10201,8 @@
                 "profile:bf2:Topic"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
             "mandatory": "false",
@@ -10759,7 +10218,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
             "remark": "http://access.rdatoolkit.org/19.3.html",
@@ -10775,7 +10235,8 @@
                 "profile:bflc:Agents:PrimaryContribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Creator of Work (RDA 19.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -10791,7 +10252,8 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
             "mandatory": "false",
@@ -10807,7 +10269,8 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
             "propertyLabel": "Related Expressions"
@@ -10824,7 +10287,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabel": ""
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
             "mandatory": "false",
@@ -10840,7 +10304,8 @@
                 "profile:bf2:35mmFeatureFilm:RelatedInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Related Manifestations (RDA Chapter 27, Appendix J)"
@@ -10853,7 +10318,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
@@ -10867,7 +10333,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
             "propertyLabel": "Your Windows ID and Comments"
@@ -10882,7 +10349,8 @@
                 "profile:bf2:35mmFeatureFilm:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Has BIBFRAME Instance",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance"
@@ -10906,7 +10374,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Search works",
@@ -10926,8 +10395,12 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
               "editable": "true",
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
-              "defaultLiteral": "two-dimensional moving image"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
+                  "defaultLiteral": "two-dimensional moving image"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -10941,7 +10414,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Date of Expression (RDA 6.10)",
             "remark": "http://access.rdatoolkit.org/6.10.html",
@@ -10960,7 +10434,8 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
-              "defaultURI": ""
+              "defaultURI": "",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -10976,7 +10451,8 @@
                 "profile:bf2:35mmFeatureFilm:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary",
@@ -10994,7 +10470,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabel": "Place of capture:"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Capture information",
             "remark": "",
@@ -11010,7 +10487,8 @@
                 "profile:bf2:35mmFeatureFilm:Event"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/eventContentOf",
             "propertyLabel": "Event"
@@ -11025,7 +10503,8 @@
                 "profile:bf2:Language:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -11043,7 +10522,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Color Content",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
@@ -11059,7 +10539,8 @@
                 "profile:bf2:35mmFeatureFilm:SoundContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Sound Content",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundContent",
@@ -11073,7 +10554,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -11087,7 +10569,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Award (RDA 7.28)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/awards",
@@ -11103,7 +10586,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes on the Expression",
             "remark": "",
@@ -11119,7 +10603,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Contributor (RDA 20.2)",
             "remark": "http://access.rdatoolkit.org/20.2.html",
@@ -11133,7 +10618,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
@@ -11143,12 +10629,7 @@
         "id": "profile:bf2:35mmFeatureFilm:ExpressionOld",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
         "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -11163,7 +10644,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
             "propertyLabel": "Search works"
@@ -11180,7 +10662,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title information"
@@ -11195,7 +10678,9 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -11211,7 +10696,8 @@
               "valueDataType": {
                 "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
                 "dataTypeLabel": "EDTF"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Work (RDA 6.4)",
@@ -11227,7 +10713,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
             "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
@@ -11241,7 +10728,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/historyOfWork",
             "propertyLabel": "History of the Work (RDA 6.7)",
@@ -11250,16 +10738,19 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "literal",
+            "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
-              "valueTemplateRefs": [],
+              "valueTemplateRefs": [
+                "profile:bf2:SourceConsulted"
+              ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
-            "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
-            "remark": "http://access.rdatoolkit.org/5.8.1.3.html"
+            "propertyLabel": "Source Consulted",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -11271,7 +10762,9 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
             "propertyLabel": "(Geographic) Coverage of the Content"
@@ -11284,7 +10777,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
@@ -11300,7 +10794,8 @@
                 "profile:bf2:Identifiers:Eidr"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Identifiers"
@@ -11312,10 +10807,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Audience"
+                "profile:bf2:Audience"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience"
@@ -11332,7 +10828,9 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -11348,7 +10846,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -11366,7 +10866,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -11382,7 +10883,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -11394,10 +10896,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -11412,7 +10915,8 @@
                 "profile:bf2:MIBluRayDVD:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -11428,7 +10932,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -11446,10 +10951,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
-              "defaultLiteral": "two-dimensional moving image",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
+                  "defaultLiteral": "two-dimensional moving image"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -11469,7 +10978,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -11482,10 +10992,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Capture"
+                "profile:bf2:Capture"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
             "propertyLabel": "Capture information"
@@ -11500,7 +11011,8 @@
                 "profile:bf2:MIBluRayDVD:Event"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/eventContentOf",
             "propertyLabel": "Event"
@@ -11513,7 +11025,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contentAccessibility",
             "propertyLabel": "Accessibility Content (RDA 7.14)",
@@ -11526,10 +11039,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -11544,7 +11058,8 @@
                 "profile:bf2:MIBluRayDVD:Color"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content"
@@ -11556,10 +11071,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:SoundContent"
+                "profile:bf2:SoundContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundContent",
             "propertyLabel": "Sound Content"
@@ -11574,7 +11090,8 @@
                 "profile:bf2:MIBluRayDVD:Aspect"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/aspectRatio",
             "propertyLabel": "Aspect Ratio"
@@ -11587,7 +11104,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -11601,7 +11119,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/awards",
             "propertyLabel": "Award (RDA 7.28)",
@@ -11617,11 +11136,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -11633,26 +11153,12 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:RelatedInstance"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Manifestations (RDA Chapter 27,  Appendix J)"
+            "propertyLabel": "Related Expressions",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -11664,7 +11170,8 @@
                 "profile:bf2:MIBluRayDVD:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -11677,7 +11184,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
@@ -11701,7 +11209,8 @@
                 "profile:bf2:MIBluRayDVD:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -11717,7 +11226,8 @@
                 "profile:bf2:ParallelTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -11732,7 +11242,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
             "remark": "http://access.rdatoolkit.org/2.4.2.html",
@@ -11747,7 +11258,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -11766,7 +11278,8 @@
                 "profile:bf2:ManufactureInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -11782,7 +11295,8 @@
                 ""
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -11798,7 +11312,8 @@
                 "profile:bf2:SeriesInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Series Statement",
             "remark": "http://access.rdatoolkit.org/2.12.html",
@@ -11818,9 +11333,13 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
               "editable": "false",
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -11843,7 +11362,8 @@
                 "profile:bf2:Identifiers:Gtin14"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Identifiers",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
@@ -11859,7 +11379,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Instance",
             "remark": "http://access.rdatoolkit.org/2.17.html",
@@ -11872,10 +11393,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -11887,10 +11409,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -11905,7 +11428,8 @@
                 "profile:bf2:MIBluRayDVD:Credits"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Cast/Credits",
             "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
@@ -11925,10 +11449,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/v",
-              "defaultLiteral": "video",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/v",
+                  "defaultLiteral": "video"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.2.html"
@@ -11947,10 +11475,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/vd",
-              "defaultLiteral": "videodisc",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/vd",
+                  "defaultLiteral": "videodisc"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.3.html"
@@ -11962,10 +11494,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:ProdMeth"
+                "profile:bf2:ProdMeth"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Production Method",
             "remark": "",
@@ -11977,10 +11510,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -11994,7 +11528,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -12009,7 +11544,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -12025,7 +11561,8 @@
                 "profile:bf2:Language:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Optional Language Tracks (MARC 546 Field)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language"
@@ -12040,7 +11577,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Optional Subtitles"
@@ -12055,7 +11593,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Accessibility Content (Closed captions/ English subtitles for the deaf and hard of hearing)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contentAccessibility"
@@ -12070,7 +11609,9 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyLabel": "LCGFT Accessibility Term (Video recordings for ... )",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm"
@@ -12085,7 +11626,8 @@
                 "profile:bf2:MIBluRayDVD:Aspect"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/aspectRatio",
             "propertyLabel": "Aspect Ratio"
@@ -12097,15 +11639,16 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Sound",
-                "profile:bf2:MIBluRayDVD:Sound3",
-                "profile:bf2:MIBluRayDVD:Sound1",
-                "profile:bf2:MIBluRayDVD:Sound2"
+                "profile:bf2:TypeRec",
+                "profile:bf2:RecMedium",
+                "profile:bf2:Playback",
+                "profile:bf2:SpecPlayback"
               ],
               "useValuesFrom": [],
               "valueDataType": {},
               "defaultURI": "",
-              "defaultLiteral": ""
+              "defaultLiteral": "",
+              "defaults": []
             },
             "propertyLabel": "Sound Characteristics",
             "remark": "",
@@ -12118,12 +11661,13 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:BroadStd"
+                "profile:bf2:BroadStd"
               ],
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BroadcastStandard"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Video Characteristics",
             "remark": "",
@@ -12136,11 +11680,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Digital",
-                "profile:bf2:MIBluRayDVD:FileType",
-                "profile:bf2:MIBluRayDVD:RegEnc",
-                "profile:bf2:MIBluRayDVD:EncFmt",
-                "profile:bf2:MIBluRayDVD:Resolution"
+                "profile:bf2:DigChar",
+                "profile:bf2:FileType",
+                "profile:bf2:RegEncoding",
+                "profile:bf2:EncFmt",
+                "profile:bf2:Resolution"
               ],
               "useValuesFrom": [],
               "valueDataType": {
@@ -12148,7 +11692,8 @@
                 "dataTypeURI": "",
                 "dataTypeLabelHint": "",
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Digital File Characteristics",
             "remark": "",
@@ -12164,7 +11709,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Recording Equipment or System Requirements (RDA 3.20.1.3)",
             "remark": "http://access.rdatoolkit.org/3.20.1.3.html",
@@ -12180,7 +11726,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyLabel": "Persons, Families, Corporate Bodies Associated with the Manifestation (RDA 21.1.2)",
             "remark": "http://access.rdatoolkit.org/rdachp21_rda21-74.html",
@@ -12193,14 +11741,15 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Source"
+                "profile:bf2:SourceConsulted"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
-            "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
-            "remark": "http://access.rdatoolkit.org/5.8.1.3.html"
+            "propertyLabel": "Source Consulted",
+            "remark": ""
           },
           {
             "propertyLabel": "Uniform Resource Locator",
@@ -12212,7 +11761,8 @@
                 "profile:bf2:MIBluRayDVD:URL"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -12228,7 +11778,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
@@ -12244,7 +11795,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Administrative Metadata for Instance",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
@@ -12259,7 +11811,8 @@
                 "profile:bf2:MIBluRayDVD:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Has Item",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem"
@@ -12282,8 +11835,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -12298,7 +11855,8 @@
                 "profile:bf2:Identifiers:Shelfmark"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -12313,7 +11871,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -12326,7 +11885,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -12340,7 +11900,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/collection",
             "propertyLabel": "Collection"
@@ -12352,7 +11913,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -12367,7 +11929,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -12384,7 +11947,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -12400,7 +11964,8 @@
                 "profile:bf2:Item:Enumeration"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology",
             "propertyLabel": "Enumeration"
@@ -12415,7 +11980,8 @@
                 "profile:bf2:Item:ImmAcqSource"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
             "propertyLabel": "Immediate Source of Acquisition of Item"
@@ -12428,7 +11994,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
             "propertyLabel": "Received date"
@@ -12442,83 +12009,13 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/instances"
-              ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Search"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "literal",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Record Related Manifestation Authorized Access Point"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
-            "propertyLabel": "Record Relationship Designator for Related Manifestation (RDA Appendix J)"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:RelatedInstance",
-        "resourceLabel": "Related Instance",
-        "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Summary",
@@ -12534,7 +12031,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note about the summary"
@@ -12554,7 +12052,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Cast/Credits note"
@@ -12578,7 +12077,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ColorContent"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -12594,7 +12094,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Details of Color Content (RDA 7.17.1.4)",
@@ -12619,9 +12120,10 @@
                 "http://id.loc.gov/vocabulary/maspect"
               ],
               "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/AspectRatio"
-              }
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AspectRatio",
+                "remark": ""
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Aspect Ratio (RDA 7.19.1.4)",
@@ -12637,7 +12139,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Details of Aspect Ratio (RDA 7.19.1.4.1.4)",
@@ -12653,7 +12156,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AspectRatio"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
             "propertyLabel": "Numerical Values of Aspect Ratio (RDA 7.19.1.3)",
@@ -12669,419 +12173,13 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:MIBluRayDVD:Place"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
-            "propertyLabel": "Place of Capture (RDA 7.11.2)",
-            "remark": "http://access.rdatoolkit.org/7.11.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "literal",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
-            "propertyLabel": "Date of Capture (RDA 7.11.3)",
-            "remark": "http://access.rdatoolkit.org/7.11.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Capture note"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Capture",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Capture",
-        "resourceLabel": "Capture information"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Place"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Place",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
-        "resourceLabel": "Place"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/maudience"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Intended Audience (RDA 7.7)",
-            "remark": "http://access.rdatoolkit.org/7.7.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note about Audience"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Audience",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience",
-        "resourceLabel": "Intended Audience"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/msoundcontent"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/SoundContent"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/msoundcontent/sound",
-              "defaultLiteral": "sound"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Sound Content (RDA 7.18)",
-            "remark": "http://access.rdatoolkit.org/7.18.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Sound Content (RDA 7.18)",
-            "remark": "http://access.rdatoolkit.org/7.18.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:SoundContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SoundContent",
-        "resourceLabel": "Sound content"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrectype"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/vocabulary/mrectype/digital",
-                "dataTypeLabelHint": ""
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/mrectype/digital",
-              "defaultLiteral": "digital",
-              "editable": "true",
-              "repeatable": "true",
-              "remark": ""
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Type of Recording (RDA 3.16.2)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Type of Recording (RDA 3.16.2.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.4.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Sound",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod",
-        "resourceLabel": "Type of Recording"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrecmedium"
-              ],
               "valueDataType": {},
-              "defaultURI": "http://id.loc.gov/vocabulary/mrecmedium/opt",
-              "defaultLiteral": "optical"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Type of Recording (RDA 3.16.3)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Recording Medium (RDA 3.16.3.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.4.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Sound3",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium",
-        "resourceLabel": "Recording Medium"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Configuration of Playback Channels (RDA 3.16.8)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Configuration of Playback Channels (RDA 3.16.8.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.4.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Sound1",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels",
-        "resourceLabel": "Playback Channels"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mspecplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Special Playback Characteristic (RDA 3.16.9)",
-            "remark": "http://access.rdatoolkit.org/3.16.9.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on Playback Characteristic"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Sound2",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic",
-        "resourceLabel": "Special Playback Characteristic"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/ProductionMethod",
-                "dataTypeLabel": "http://id.loc.gov/ontologies/bflc/target"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Production Method (RDA 3.9.1.3)",
-            "remark": "http://access.rdatoolkit.org/3.9.1.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Production Method (RDA 3.9.1.4)",
-            "remark": "http://access.rdatoolkit.org/3.9.1.4.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:ProdMeth",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod",
-        "resourceLabel": "Production Method"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "defaults": []
             },
             "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
             "remark": "http://access.rdatoolkit.org/4.6.html",
@@ -13097,7 +12195,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on URL"
@@ -13112,227 +12211,13 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mregencoding"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/RegionalEncoding"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Regional Encoding (RDA 3.19.6.3)",
-            "remark": "http://access.rdatoolkit.org/3.19.6.3.html"
-          }
-        ],
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RegionalEncoding",
-        "id": "profile:bf2:MIBluRayDVD:RegEnc",
-        "resourceLabel": "Regional Encoding"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "literal",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Encoding Format (RDA 3.19.3)",
-            "remark": "http://access.rdatoolkit.org/3.19.3.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:EncFmt",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/EncodingFormat",
-        "resourceLabel": "Encoding Format"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mfiletype"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/FileType"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/mfiletype/video",
-              "defaultLiteral": "video file",
-              "remark": "http://id.loc.gov/vocabulary/mfiletype/video"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "File Type (RDA 3.19.2)",
-            "remark": "http://access.rdatoolkit.org/3.19.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "remark": "http://access.rdatoolkit.org/3.19.2.4.html",
-            "propertyLabel": "Details of File Type (RDA 3.19.2.4)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:FileType",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileType",
-        "resourceLabel": "File type"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "remark": "http://access.rdatoolkit.org/3.19.1.4.html",
-            "propertyLabel": "Details of Digital File Characteristic (RDA 3.19.1.4)"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Digital",
-        "resourceLabel": "Digital Characteristics",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/DigitalCharacteristic"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mbroadstd"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/BroadcastStandard"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Broadcast Standard (RDA 3.18.3)",
-            "remark": "http://access.rdatoolkit.org/3.18.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Broadcast Standard (RDA 3.18.3.4)",
-            "remark": "http://access.rdatoolkit.org/3.18.3.4.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:BroadStd",
-        "resourceLabel": "Broadcast Standard",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/BroadcastStandard"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Resolution (RDA 3.19.5)",
-            "remark": "http://access.rdatoolkit.org/3.19.5.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Resolution",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Resolution",
-        "resourceLabel": "Resolution"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Event"
@@ -13345,7 +12230,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
             "propertyLabel": "Date of Event"
@@ -13354,27 +12240,6 @@
         "id": "profile:bf2:MIBluRayDVD:Event",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Event",
         "resourceLabel": "Event"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
-            "remark": "http://access.rdatoolkit.org/5.8.1.3.html"
-          }
-        ],
-        "id": "profile:bf2:MIBluRayDVD:Source",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Source",
-        "resourceLabel": "Source Consulted"
       },
       {
         "id": "profile:bf2:MIBluRayDVD:WorkOld",
@@ -13392,7 +12257,8 @@
               "valueTemplateRefs": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -13409,7 +12275,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Creator of Work (RDA 19.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -13427,7 +12294,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -13443,7 +12311,8 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -13461,7 +12330,8 @@
                 "dataTypeLabel": "EDTF",
                 "dataTypeLabelHint": "ISO",
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.4.html",
             "mandatory": "false",
@@ -13478,7 +12348,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.5.html",
             "mandatory": "false",
@@ -13492,7 +12363,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "History of the Work (RDA 6.7)",
             "remark": "http://access.rdatoolkit.org/rdachp6_rda6-3332.html",
@@ -13506,7 +12378,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
             "remark": "http://access.rdatoolkit.org/5.8.1.3.html",
@@ -13521,7 +12394,8 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -13536,7 +12410,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
@@ -13552,7 +12427,8 @@
                 "profile:bf2:Identifiers:Eidr"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Identifiers"
@@ -13569,7 +12445,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "editable": "true",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -13585,7 +12462,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
             "remark": "http://access.rdatoolkit.org/19.3.html",
@@ -13601,7 +12479,8 @@
                 "profile:bf2:Topic"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
             "mandatory": "false",
@@ -13614,7 +12493,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work",
@@ -13634,7 +12514,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Classification numbers",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
@@ -13649,7 +12530,8 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
             "mandatory": "false",
@@ -13665,7 +12547,8 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
             "propertyLabel": "Related Expressions"
@@ -13679,7 +12562,8 @@
                 "profile:bf2:MIBluRayDVD:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -13696,7 +12580,8 @@
                 "profile:bf2:MIBluRayDVD:Expression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -13712,7 +12597,8 @@
                 "profile:bf2:MIBluRayDVD:RelatedInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Related Manifestations (RDA Chapter 27,  Appendix J)"
@@ -13725,7 +12611,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Work (RDA 6.27.1)",
@@ -13739,7 +12626,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
             "propertyLabel": "Your Windows ID and Comments"
@@ -13754,7 +12642,8 @@
                 "profile:bf2:MIBluRayDVD:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Has BIBFRAME Instance",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance"
@@ -13778,7 +12667,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Search works",
@@ -13798,8 +12688,12 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
               "editable": "true",
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
-              "defaultLiteral": "two-dimensional moving image"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/tdi",
+                  "defaultLiteral": "two-dimensional moving image"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -13813,7 +12707,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Date of Expression (RDA 6.10)",
             "remark": "http://access.rdatoolkit.org/6.10.html",
@@ -13831,7 +12726,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -13847,7 +12743,8 @@
                 "profile:bf2:MIBluRayDVD:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary",
@@ -13865,7 +12762,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabel": ""
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Capture information",
             "remark": "",
@@ -13881,7 +12779,8 @@
                 "profile:bf2:MIBluRayDVD:Event"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/eventContentOf",
             "propertyLabel": "Event"
@@ -13898,7 +12797,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -13912,7 +12812,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Accessibility Content (RDA 7.14)",
             "remark": "http://access.rdatoolkit.org/7.14.html",
@@ -13928,7 +12829,8 @@
                 "profile:bf2:MIBluRayDVD:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content",
@@ -13946,7 +12848,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "remark": "",
             "propertyLabel": "Color Content",
@@ -13962,7 +12865,8 @@
                 "profile:bf2:MIBluRayDVD:SoundContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "propertyLabel": "Sound Content",
@@ -13978,7 +12882,8 @@
                 "profile:bf2:MIBluRayDVD:Aspect"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Aspect Ratio",
             "remark": "",
@@ -13994,7 +12899,8 @@
                 ""
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -14008,7 +12914,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Award (RDA 7.28)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/awards",
@@ -14024,7 +12931,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Expression"
@@ -14039,7 +12947,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Contributor (RDA 20.2)",
             "remark": "http://access.rdatoolkit.org/20.2.html",
@@ -14053,7 +12962,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
@@ -14063,12 +12973,7 @@
         "id": "profile:bf2:MIBluRayDVD:ExpressionOld",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
         "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -14083,7 +12988,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Lookup BIBFRAME works"
@@ -14100,7 +13006,10 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false",
+              "repeatable": "true"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -14118,7 +13027,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
@@ -14131,7 +13041,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point Representing the Musical Work (RDA 6.28.1)",
@@ -14147,7 +13058,9 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -14160,7 +13073,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Work (RDA 6.4)",
@@ -14176,7 +13090,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
             "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
@@ -14189,10 +13104,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:MOPStatement"
+                "profile:bf2:MOPStatement"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
             "propertyLabel": "Medium of Performance Statement"
@@ -14207,7 +13123,8 @@
                 "profile:bf2:PMOMedPerf:DecMed"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
             "propertyLabel": "Medium of Performance"
@@ -14222,7 +13139,8 @@
                 "profile:bf2:PMOMedPerf:DecMed"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/alternateMediumOfPerformance",
             "propertyLabel": "Alternate Declared Medium"
@@ -14234,13 +13152,14 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:PMOMedPerf:DecMed"
+                "profile:bf2:PMOMedPerf:Doubling"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Doubling Declared Medium",
-            "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance"
+            "propertyURI": "http://performedmusicontology.org/ontology/hasMdeiumPart"
           },
           {
             "mandatory": "false",
@@ -14250,7 +13169,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber",
             "propertyLabel": "Music Serial Number (RDA 6.16.1.3.1)",
@@ -14264,7 +13184,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicOpusNumber",
             "propertyLabel": "Music Opus Number (RDA 6.16.1.3.2)",
@@ -14278,7 +13199,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicThematicNumber",
             "propertyLabel": "Thematic Index Number (RDA 6.16.1.3.3)",
@@ -14292,7 +13214,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
             "propertyLabel": "Key (RDA 6.17)",
@@ -14310,7 +13233,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience (RDA 7.7)",
@@ -14326,7 +13250,10 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false",
+              "repeatable": "true"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -14344,7 +13271,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -14360,7 +13288,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -14376,7 +13305,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -14388,10 +13318,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -14403,10 +13334,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -14424,10 +13356,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
-              "defaultLiteral": "Notated music",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
+                  "defaultLiteral": "Notated music"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -14447,7 +13383,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -14461,7 +13398,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Script (RDA 7.13.2)",
@@ -14477,7 +13415,8 @@
                 "profile:bf2:NotatedMusic:Notation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Form of Musical Notation"
@@ -14494,7 +13433,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content (RDA 7.15)",
@@ -14507,10 +13447,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -14525,7 +13466,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -14543,7 +13485,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicFormat"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicFormat",
             "propertyLabel": "Format of Notated Music (RDA 7.20)",
@@ -14557,7 +13500,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -14573,11 +13517,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -14589,11 +13534,12 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
+            "propertyLabel": "Related Expressions",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -14605,7 +13551,8 @@
                 "profile:bf2:NotatedMusic:Instance2"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Add BIBFRAME Instance"
@@ -14620,7 +13567,8 @@
                 "profile:bf2:PMOMedPerf:DecMedTest"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
             "propertyLabel": "Declared Medium Test"
@@ -14644,7 +13592,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Search Existing RDA/BIBFRAME Work"
@@ -14657,7 +13606,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Agent + Preferred Title + AAP Expression Elements"
@@ -14675,8 +13625,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
-              "defaultLiteral": "Notated music"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
+                  "defaultLiteral": "Notated music"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -14690,7 +13644,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Expression (RDA 6.10)",
@@ -14708,7 +13663,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -14721,10 +13677,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary of Content (RDA 7.10)",
@@ -14738,7 +13695,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Script (RDA 7.13.2)",
@@ -14751,10 +13709,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:MOPStatement"
+                "profile:bf2:MOPStatement"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
             "propertyLabel": "Medium of Performance Statement"
@@ -14769,7 +13728,8 @@
                 "profile:bf2:PMOMedPerf:DecMed"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
             "propertyLabel": "Declared Medium"
@@ -14784,7 +13744,8 @@
                 "profile:bf2:PMOMedPerf:DecMed"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Alternate Declared Medium",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/alternateMediumOfPerformance"
@@ -14799,7 +13760,8 @@
                 "profile:bf2:PMOMedPerf:DecMed"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance",
             "propertyLabel": "Doubling Declared Medium"
@@ -14814,7 +13776,8 @@
                 "profile:bf2:NotatedMusic:Notation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Form of Musical Notation"
@@ -14833,7 +13796,8 @@
                 "remark": "",
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
               },
-              "defaultURI": ""
+              "defaultURI": "",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content (RDA 7.15)",
@@ -14846,10 +13810,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -14864,7 +13829,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -14882,7 +13848,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicFormat"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicFormat",
             "propertyLabel": "Format of Notated Music (RDA 7.20)",
@@ -14896,7 +13863,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -14912,7 +13880,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contributor (RDA 20.2)",
@@ -14928,11 +13898,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -14944,11 +13915,12 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-24.html"
+            "propertyLabel": "Related Expressions",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -14960,7 +13932,8 @@
                 "profile:bf2:NotatedMusic:Instance2"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Add BIBFRAME Instance"
@@ -14986,7 +13959,8 @@
                 "profile:bf2:Title:CollTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information (RDA 2.3)"
@@ -14999,7 +13973,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
@@ -15013,7 +13988,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
             "propertyLabel": "Edition Statement (RDA 2.5)",
@@ -15031,7 +14007,8 @@
                 "profile:bf2:ManufactureInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
             "propertyLabel": "Publication, Distribution, Manufacture Statements"
@@ -15044,7 +14021,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -15060,7 +14038,8 @@
                 "profile:bf2:SeriesInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
             "propertyLabel": "Series Statement"
@@ -15078,8 +14057,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -15102,7 +14085,8 @@
                 "profile:bf2:Identifiers:Local"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Identifiers"
@@ -15117,7 +14101,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Instance",
@@ -15136,8 +14121,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
-              "defaultLiteral": "unmediated"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                  "defaultLiteral": "unmediated"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
             "propertyLabel": "Media type (RDA 3.2)",
@@ -15156,8 +14145,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
-              "defaultLiteral": "volume"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                  "defaultLiteral": "volume"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
             "propertyLabel": "Carrier Type (RDA 3.3)",
@@ -15170,10 +14163,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
             "propertyLabel": "Extent"
@@ -15186,7 +14180,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
             "propertyLabel": "Dimensions (RDA 3.5)",
@@ -15204,7 +14199,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
             "propertyLabel": "Base Material (RDA 3.6)",
@@ -15222,7 +14218,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/appliedMaterial",
             "propertyLabel": "Applied Material (RDA 3.7)",
@@ -15240,7 +14237,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
             "propertyLabel": "Production Method (RDA 3.9.1.3)",
@@ -15254,7 +14252,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
             "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
@@ -15270,7 +14269,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
@@ -15286,7 +14286,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
             "propertyLabel": "Administrative Metadata for Instance"
@@ -15301,7 +14302,8 @@
                 "profile:bf2:NotatedMusic:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
             "propertyLabel": "Add Item"
@@ -15325,7 +14327,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "resourceTemplates": [],
             "mandatory": "false",
@@ -15346,7 +14349,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15361,7 +14365,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
             "remark": "http://access.rdatoolkit.org/2.4.2.html",
@@ -15374,7 +14379,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15393,7 +14399,8 @@
                 "profile:bf2:ManufactureInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15407,7 +14414,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -15423,7 +14431,8 @@
                 "profile:bf2:SeriesInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Series Statement",
             "remark": "",
@@ -15442,10 +14451,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -15468,7 +14481,8 @@
                 "profile:bf2:Identifiers:Local"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15484,7 +14498,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Instance",
             "remark": "http://access.rdatoolkit.org/2.17.html",
@@ -15504,10 +14519,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
-              "defaultLiteral": "unmediated",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                  "defaultLiteral": "unmediated"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.2.html"
@@ -15526,10 +14545,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
-              "defaultLiteral": "volume",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                  "defaultLiteral": "volume"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.3.html"
@@ -15540,10 +14563,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:NotatedMusic:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15557,7 +14581,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15576,7 +14601,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
             "propertyLabel": "Base Material (RDA 3.6)",
@@ -15594,7 +14620,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/appliedMaterial",
             "propertyLabel": "Applied Material (RDA 3.7)",
@@ -15612,7 +14639,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
             "propertyLabel": "Production Method (RDA 3.9.1.3)",
@@ -15626,7 +14654,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15642,7 +14671,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
@@ -15658,7 +14688,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Administrative Metadata for Instance",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
@@ -15673,10 +14704,28 @@
                 "profile:bf2:NotatedMusic:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
             "propertyLabel": "Has Item"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:RelatedWork"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyLabel": "Related Works",
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
+            "remark": ""
           }
         ],
         "resourceLabel": "BIBFRAME Instance",
@@ -15696,8 +14745,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -15711,7 +14764,8 @@
                 "profile:bf2:Identifiers:LC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15726,7 +14780,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15739,7 +14794,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15752,7 +14808,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15767,7 +14824,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15784,7 +14842,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -15799,253 +14858,6 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "id": "profile:bf2:NotatedMusic:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
-          }
-        ],
-        "id": "profile:bf2:NotatedMusic:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": ""
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrumentalType",
-            "propertyLabel": "Type of instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:NotatedMusic:MedPerfInst",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument",
-        "resourceLabel": "Instrument"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/voiceType",
-            "propertyLabel": "Type of voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:NotatedMusic:MedPerfVoice",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice",
-        "resourceLabel": "Voice"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensembleType",
-            "propertyLabel": "Type of Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:NotatedMusic:MedPerfEnsemble",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble",
-        "resourceLabel": "Ensemble"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "target",
             "resourceTemplates": [],
             "valueConstraint": {
@@ -16054,8 +14866,9 @@
                 "http://id.loc.gov/vocabulary/mmusnotation"
               ],
               "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Notation"
-              }
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicNotation"
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Form of Musical Notation (RDA 7.13.3)",
@@ -16071,7 +14884,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/7.13.3.4.html",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
@@ -16081,99 +14895,6 @@
         "id": "profile:bf2:NotatedMusic:Notation",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicNotation",
         "resourceLabel": "Form of Musical Notation"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:NotatedMusic:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:NotatedMusic:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Medium of Performance (RDA 7.21)",
-            "remark": "http://access.rdatoolkit.org/7.21.html"
-          }
-        ],
-        "id": "profile:bf2:NotatedMusic:MOPStatement",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
-        "resourceLabel": "Medium of Performance Statement"
       },
       {
         "id": "profile:bf2:NotatedMusic:WorkOld",
@@ -16191,7 +14912,8 @@
               "valueTemplateRefs": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -16208,7 +14930,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Creator of Work (RDA 19.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -16226,7 +14949,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -16242,7 +14966,8 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -16255,7 +14980,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.4.html",
             "mandatory": "false",
@@ -16272,7 +14998,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.5.html",
             "mandatory": "false",
@@ -16289,7 +15016,8 @@
                 "profile:bf2:NotatedMusic:MediumOfPerformanceCombining"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Medium of Performance (RDA 6.15)",
             "remark": "http://access.rdatoolkit.org/6.15.html",
@@ -16307,7 +15035,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -16322,7 +15051,8 @@
                 "profile:bf2:NotatedMusic:MedPerfVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -16337,7 +15067,8 @@
                 "profile:bf2:NotatedMusic:MedPerfEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -16350,7 +15081,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Numerical Designation of a Musical Work (RDA 6.16)",
             "remark": "http://access.rdatoolkit.org/6.16.html",
@@ -16364,7 +15096,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Key (RDA 6.17)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
@@ -16382,7 +15115,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/7.7.html",
             "mandatory": "false",
@@ -16398,7 +15132,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
             "remark": "http://access.rdatoolkit.org/19.3.html",
@@ -16414,7 +15149,8 @@
                 "profile:bf2:Topic"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
             "mandatory": "false",
@@ -16427,7 +15163,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work",
@@ -16447,7 +15184,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -16462,7 +15200,8 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
             "mandatory": "false",
@@ -16478,7 +15217,8 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
             "propertyLabel": "Related Expressions"
@@ -16492,7 +15232,8 @@
                 "profile:bf2:NotatedMusic:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -16507,7 +15248,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Authorized Access Point Representing the Musical Work (RDA 6.28.1)",
             "remark": "http://access.rdatoolkit.org/6.28.1.html",
@@ -16523,7 +15265,8 @@
                 "profile:bf2:NotatedMusic:Expression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Expression elements",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression"
@@ -16536,7 +15279,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
             "propertyLabel": "Your Windows ID and Comments"
@@ -16551,7 +15295,8 @@
                 "profile:bf2:NotatedMusic:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -16575,7 +15320,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Lookup",
@@ -16594,7 +15340,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
             "propertyLabel": "Medium of Performance of the Musical Expression",
@@ -16612,7 +15359,8 @@
                 "profile:bf2:NotatedMusic:MedPerfEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
             "propertyLabel": "Medium of Performance (New)"
@@ -16630,8 +15378,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
-              "defaultLiteral": "Notated music"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/ntm",
+                  "defaultLiteral": "Notated music"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -16645,7 +15397,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Expression (RDA 6.10)",
@@ -16663,7 +15416,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -16679,7 +15433,8 @@
                 "profile:bf2:NotatedMusic:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary",
@@ -16695,7 +15450,8 @@
                 "profile:bf2:Language:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -16709,7 +15465,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Script (RDA 7.13.2)",
@@ -16725,7 +15482,8 @@
                 "profile:bf2:NotatedMusic:Notation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Form of Musical Notation",
@@ -16743,7 +15501,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content (RDA 7.15)",
@@ -16759,7 +15518,8 @@
                 "profile:bf2:NotatedMusic:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "remark": "",
@@ -16777,7 +15537,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -16795,7 +15556,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicFormat"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Format of Notated Music (RDA 7.20)",
             "remark": "http://access.rdatoolkit.org/7.20.html",
@@ -16809,7 +15571,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -16825,7 +15588,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Expression",
             "remark": "",
@@ -16841,7 +15605,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Contributor (RDA 20.2)",
             "remark": "http://access.rdatoolkit.org/20.2.html",
@@ -16855,7 +15620,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point Representing the Musical Expression (RDA 6.28.3)",
@@ -16876,7 +15642,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Total Number of Performers: Individual Instruments (no ensemble present)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
@@ -16891,7 +15658,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Record complete instrumentation as text field"
@@ -16904,7 +15672,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
             "propertyLabel": "Total Number of Performers: Individual Instruments (ensemble present)"
@@ -16919,7 +15688,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Record complete instrumentation as text field",
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
@@ -16932,7 +15702,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Total Number of Ensembles",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
@@ -16956,7 +15727,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Search Individual Instrument or Ensemble in LCMPT ... OR ...",
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
@@ -16971,7 +15743,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Record Individual Instrument or Ensemble",
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
@@ -16984,7 +15757,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Number of Parts: Individual Instrument ... AND/OR ...",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
@@ -16997,7 +15771,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Number of Performers: Individual Instrument ... AND/OR ...",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
@@ -17010,7 +15785,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Number of Players: Percussion ... AND/OR ...",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
@@ -17023,7 +15799,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Number of Hands: Individual instrument ... AND/OR ...",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
@@ -17036,7 +15813,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Number of Ensembles",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/count"
@@ -17053,7 +15831,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Search Doubling Medium of Performance ... OR ...",
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
@@ -17068,7 +15847,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Record Doubling Medium of Performance",
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
@@ -17085,7 +15865,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Search Alternative Instrumentation Medium of Performance ... OR ..."
@@ -17100,7 +15881,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Record Alternative Instrumentation Medium of Performance"
@@ -17115,7 +15897,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Note on Instrumentation",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
@@ -17124,12 +15907,45 @@
         "id": "profile:bf2:NotatedMusic:MediumOfPerformanceIndividual",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
         "resourceLabel": "Medium of Performance: Individual Facets"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Contents note",
+            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "URI for contents"
+          }
+        ],
+        "id": "profile:bf2:Contents",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
+        "resourceLabel": "Contents note"
+      },
       {
         "propertyTemplates": [
           {
@@ -17142,7 +15958,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "editable": "true",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Note"
@@ -17162,7 +15979,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Script"
@@ -17171,17 +15989,119 @@
         "id": "profile:bf2:Script",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Script",
         "resourceLabel": "Script"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Source Consulted (RDA 5.8.1.3)",
+            "remark": "http://access.rdatoolkit.org/5.8.1.3.html"
+          }
+        ],
+        "id": "profile:bf2:SourceConsulted",
+        "resourceLabel": "Source Consulted",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Source"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Summary note",
+            "remark": "http://access.rdatoolkit.org/7.10.html"
+          }
+        ],
+        "id": "profile:bf2:Summary",
+        "resourceLabel": "Summary note",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+              }
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Supplementary Content (RDA 7.16)",
+            "remark": "http://access.rdatoolkit.org/7.16.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "URI for Supplementary Content"
+          }
+        ],
+        "id": "profile:bf2:SupplContent",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
+        "resourceLabel": "Supplementary Content"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "System Requirement (RDA 3.20)",
+            "remark": "http://access.rdatoolkit.org/3.20.html"
+          }
+        ],
+        "id": "profile:bf2:SysReq",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SystemRequirement",
+        "resourceLabel": "System Requirement"
+      },
       {
         "propertyTemplates": [
           {
             "mandatory": "false",
             "repeatable": "false",
-            "type": "lookup",
+            "type": "target",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
@@ -17193,10 +16113,11 @@
                 "remark": "",
                 "dataTypeURI": ""
               },
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyLabel": "Search LCNAF/LCSH",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Place"
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
           },
           {
             "mandatory": "false",
@@ -17210,7 +16131,8 @@
                 "dataTypeURI": "",
                 "remark": "http://id.loc.gov/ontologies/bibframe/Place"
               },
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Record Place (if it does not appear above)",
@@ -17220,1072 +16142,8 @@
         "id": "profile:bf2:Place",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
         "resourceLabel": "Place Associated with a Work",
-        "contact": ""
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/works"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
-            "propertyLabel": "Lookup"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Graphics:StatementOfResponsibility"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "1. Title and Statement of Responsibility Area",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
-            "remark": "http://desktop.loc.gov/saved/1._Title_and_Statement_of_Responsibility_Area"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bflc:Agents:PrimaryContribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "propertyLabel": "Creator(s)"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Graphics:Publication"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "4. Publication, Distribution, Production, Etc., Area",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
-            "remark": "http://desktop.loc.gov/saved/PublicationDistributionProduction"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Agents:Contribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Contributor(s)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "2. State Area",
-            "remark": "http://desktop.loc.gov/saved/StateArea",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/state"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Graphics:Series"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "6. Series and Multipart Resource",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
-            "remark": "http://desktop.loc.gov/saved/6._Series_and_Multipart_Resource_Area"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Graphics:Description"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "5. Physical Description",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Instance",
-            "remark": "http://desktop.loc.gov/saved/5._Physical_Description_Area"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:ISBN"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "8. Standard Number and Terms of Availability",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "remark": "http://desktop.loc.gov/saved/8._Standard_Number_and_Terms_of_Availability_Area"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Source of Acquisition (Reproduction number)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/acquisitionSource"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/contentTypes"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
-              },
-              "editable": "false",
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/sti",
-              "defaultLiteral": "still image"
-            },
-            "propertyLabel": "Content Type",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Graphics:Notes"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7. Notes",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "remark": "http://desktop.loc.gov/saved/7._Note_Area"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mediaTypes"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
-              },
-              "editable": "false",
-              "defaultLiteral": "unmediated",
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n"
-            },
-            "propertyLabel": "Media Type",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/media"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Topic"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Subject Access",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/carriers"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
-              },
-              "editable": "false",
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/nb",
-              "defaultLiteral": "sheet"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
-            "propertyLabel": "Carrier Type"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:Shelfmark"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Call Number",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/shelfMark"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Biographical or Historical Data",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/historyOfWork"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Ownership and Custodial History",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/custodialHistory"
-          }
-        ],
-        "resourceLabel": "Single Photograph",
-        "id": "profile:bf2:Graphics:Work",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work"
+        "author": "NDMSO"
       },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
-            "propertyLabel": "1B. Transcribed title proper",
-            "remark": "http://desktop.loc.gov/search?view=document&id=Infobasedcrmg0Dash0Dash0Dash247&hl=true&fq=allresources|true#"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/StillImage",
-            "propertyLabel": "1C. General material designation",
-            "remark": "http://desktop.loc.gov/saved/GeneralMaterialDesignation"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                ""
-              ],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ParallelTitle",
-            "propertyLabel": "1D. Parallel titles",
-            "remark": "http://desktop.loc.gov/saved/ParallelTitles"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                ""
-              ],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle",
-            "propertyLabel": "1E. Other title information",
-            "remark": "http://desktop.loc.gov/saved/OtherTitleInformation"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "1F. Supplied and devised titles",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Title",
-            "remark": "http://desktop.loc.gov/saved/SuppliedDevisedTitles"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
-            "propertyLabel": "1G. Statements of responsibility",
-            "remark": "http://desktop.loc.gov/saved/StatementsOfResponsibility"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "1H. Material without a collective title",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Title",
-            "remark": "http://desktop.loc.gov/saved/1H._Material_without_a_collective_title"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Translation of title by cataloging agency",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Title"
-          }
-        ],
-        "resourceLabel": "Title and Statement of Responsibility",
-        "id": "profile:bf2:Graphics:StatementOfResponsibility",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Title"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "4B. Place of publication, distribution, production, etc.",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Place",
-            "remark": "http://desktop.loc.gov/saved/PlacePublicationDistributionProduction"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "4C. Name of publisher, distributor, etc.",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Agent",
-            "remark": "http://desktop.loc.gov/saved/NamePublisherDistributor"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "4D. Date of publication, distribution, production, etc.",
-            "remark": "http://desktop.loc.gov/saved/DatePublicationDistributionProduction",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "4E. Place of manufacture",
-            "remark": "http://desktop.loc.gov/saved/PlaceManufacture",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Place"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "4F. Name of manufacturer",
-            "remark": "http://desktop.loc.gov/saved/NameManufacturer",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Agent"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                ""
-              ],
-              "valueDataType": {}
-            },
-            "propertyLabel": "4G. Date of manufacture",
-            "remark": "http://desktop.loc.gov/saved/DateManufacture",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Copyright date",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate"
-          }
-        ],
-        "resourceLabel": "Publication, Distribution, Production",
-        "id": "profile:bf2:Graphics:Publication",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/ProvisionActivity"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "5B. Extent",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
-            "remark": "http://desktop.loc.gov/saved/5B. Extent (including specific material designatio"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "5C. Other physical details",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/otherPhysicalDetails",
-            "remark": "http://desktop.loc.gov/saved/5C._Other_physical_details"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "5D. Dimensions and format",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
-            "remark": "http://desktop.loc.gov/saved/5D._Dimensions_and_format"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "5E. Accompanying material",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy",
-            "remark": "http://desktop.loc.gov/saved/5E._Accompanying_material"
-          }
-        ],
-        "resourceLabel": "Physical Description",
-        "id": "profile:bf2:Graphics:Description",
-        "resourceURI": "http://id.loc.gov/ontologies/bflc/physicalDescription"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "6B. Title proper of series or multipart resource",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesStatement",
-            "remark": "http://desktop.loc.gov/saved/6B._Title_proper_of_series_or_multipart_resource"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "6C. Parallel titles of series or multipart resource",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesStatement",
-            "remark": "http://desktop.loc.gov/saved/6C. Parallel titles of series and multipart resour"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "6D. Other title information of series or multipart resource",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesStatement",
-            "remark": "http://desktop.loc.gov/saved/6D. Other title information of series and multipar"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "6E. Statements of responsibility relating to series or multipart resource",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesStatement",
-            "remark": "http://desktop.loc.gov/saved/Statements of responsibility relating to series an"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "6F. Numbering within series or multipart resource",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesEnumeration",
-            "remark": "http://desktop.loc.gov/saved/Numbering within series and multipart resources"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "6G. Subseries",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/subseriesOf",
-            "remark": "http://desktop.loc.gov/saved/6G._Subseries"
-          }
-        ],
-        "id": "profile:bf2:Graphics:Series",
-        "resourceLabel": "Series and Multipart Resource",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B1. Summary (nature, scope, artistic form, etc.)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
-            "remark": "http://desktop.loc.gov/saved/7B1. Summary (nature, scope, artistic form, etc.)"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B2. Language and script",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
-            "remark": "http://desktop.loc.gov/saved/http://desktop.loc.gov/saved/7B1. Summary (nature,"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                ""
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {},
-              "editable": "false",
-              "repeatable": "false",
-              "defaultLiteral": "Title devised by Library staff"
-            },
-            "propertyLabel": "7B3. Source of description; source of title proper",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
-            "remark": "http://desktop.loc.gov/saved/7B3. Source of description; source of title proper"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B4. Variations in title",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle",
-            "remark": "http://desktop.loc.gov/saved/7B._Notes"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                ""
-              ],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B5. Parallel titles, continuation of title, and other title information",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ParallelTitle",
-            "remark": "http://desktop.loc.gov/saved/7B._Notes"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B6. Statements of responsibility",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B7. State and printing history",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/state"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B8. Publication, distribution, production, etc.",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B9. Physical description",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B10. Accompanying material",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                ""
-              ],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B11. Series",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesStatement"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B12. References to published descriptions",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/referencedBy"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B13. Characteristics of original of a copy",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Generation"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B14. Contents",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B15. Numbers or letters",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B16. Relationship note",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/Relationship"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B17. “With” notes",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuedWith"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B18. Terms of access, use, and reproduction",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B19. Preferred citation",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/preferredCitation"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B20. Provenance",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B21. Immediate source of acquisition",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B22. Additional physical format",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/otherPhysicalFormat"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "7B23. Exhibition history",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/exhibitionHistory"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "General note",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          }
-        ],
-        "id": "profile:bf2:Graphics:Notes",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/note",
-        "resourceLabel": "Notes"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "8B. Standard number (ISBN)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Isbn"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "8C. Terms of availability",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/acquisitionTerms"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "8D. Qualification",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/qualifier"
-          }
-        ],
-        "id": "profile:bf2:Graphics:Identifier",
-        "resourceLabel": "Standard Number and Terms of Availability",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Identifier"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
       {
         "propertyTemplates": [
           {
@@ -18300,7 +16158,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
             "propertyLabel": "Place",
@@ -18318,7 +16177,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
             "propertyLabel": "Name",
@@ -18332,15 +16192,32 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
             "propertyLabel": "Date (RDA 2.8.6)",
             "remark": "http://access.rdatoolkit.org/2.8.6.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note about publisher"
           }
         ],
         "id": "profile:bf2:PublicationInformation",
-        "contact": "",
+        "author": "NDMSO",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Publication",
         "resourceLabel": "Publication Activity"
       },
@@ -18358,7 +16235,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
             "propertyLabel": "Place",
@@ -18376,7 +16254,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
             "propertyLabel": "Name",
@@ -18390,7 +16269,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
             "propertyLabel": "Date (RDA 2.9.6)",
@@ -18406,11 +16286,28 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Statement of Function (RDA 2.9.4.4)",
             "remark": "http://access.rdatoolkit.org/2.9.4.4.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note about distributor"
           }
         ],
         "resourceLabel": "Distribution Activity",
@@ -18433,7 +16330,8 @@
                 "dataTypeURI": ""
               },
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
             "propertyLabel": "Place",
@@ -18453,7 +16351,8 @@
                 "dataTypeURI": ""
               },
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
             "propertyLabel": "Name",
@@ -18467,11 +16366,28 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
             "propertyLabel": "Date (RDA 2.10.6)",
             "remark": "http://access.rdatoolkit.org/2.10.6.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note about manufacturer"
           }
         ],
         "id": "profile:bf2:ManufactureInformation",
@@ -18490,7 +16406,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Place (RDA 2.10.2)",
@@ -18513,7 +16430,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Name (RDA 2.8.4)",
@@ -18536,7 +16454,8 @@
                 "profile:bf2:Provision:PlaceTest"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
             "propertyLabel": "Place"
@@ -18551,7 +16470,8 @@
                 "profile:bf2:Provision:NameTest"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
             "propertyLabel": "Name"
@@ -18564,7 +16484,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
             "propertyLabel": "Date"
@@ -18577,7 +16498,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivityStatement",
             "propertyLabel": "Provision activity statement"
@@ -18599,7 +16521,10 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {}
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Place"
@@ -18621,7 +16546,10 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {}
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Name"
@@ -18630,11 +16558,7 @@
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Agent",
         "id": "profile:bf2:Provision:NameTest",
         "resourceLabel": "Name Test"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -19554,12 +17478,8 @@
         "id": "profile:bf2:Agent:RWO",
         "resourceURI": "http://www.loc.gov/mads/rdf/v1#RWO",
         "resourceLabel": "Other Identifying Attributes",
-        "contact": "NDMSO"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+        "author": "NDMSO"
+      },
       {
         "propertyTemplates": [
           {
@@ -19574,7 +17494,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Lookup"
@@ -19591,7 +17512,9 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -19609,7 +17532,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information"
@@ -19624,7 +17548,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -19642,7 +17567,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -19660,7 +17586,9 @@
                 "profile:bf2:RareMat:AAT"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "true"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -19677,7 +17605,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience (RDA 7.7)",
@@ -19693,7 +17622,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -19705,10 +17635,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:RareMat:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -19720,10 +17651,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:RareMat:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -19739,7 +17671,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -19757,10 +17690,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
-              "defaultLiteral": "text",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                  "defaultLiteral": "text"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -19780,7 +17717,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -19796,7 +17734,8 @@
                 "profile:bf2:RareMat:Illus"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content"
@@ -19811,7 +17750,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -19824,10 +17764,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:RareMat:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -19842,11 +17783,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -19858,7 +17800,8 @@
                 "profile:bf2:RareMat:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -19871,7 +17814,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
@@ -19894,7 +17838,8 @@
                 "profile:bf2:RareMat:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instanceOf",
             "propertyLabel": "Instance of"
@@ -19915,7 +17860,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information"
@@ -19928,7 +17874,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
             "propertyLabel": "Statement of responsiblity",
@@ -19942,7 +17889,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
             "propertyLabel": "Edition Statement (RDA 2.5)",
@@ -19958,7 +17906,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contributors"
@@ -19975,7 +17925,8 @@
                 "profile:bf2:ManufactureInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
             "propertyLabel": "Publication, Distribution, Manufacture Statements"
@@ -19988,7 +17939,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -20004,7 +17956,8 @@
                 "profile:bf2:SeriesInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
             "propertyLabel": "Series Statement"
@@ -20020,7 +17973,8 @@
                 "profile:bf2:RareMat:RBMS"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Instance"
@@ -20037,7 +17991,8 @@
                 "profile:bf2:Identifiers:Local"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Identifier for the Manifestation"
@@ -20052,7 +18007,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Instance",
@@ -20068,9 +18024,10 @@
                 "profile:bf2:RareMat:RefWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/references",
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
             "propertyLabel": "References"
           },
           {
@@ -20086,10 +18043,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -20108,10 +18069,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
-              "defaultLiteral": "unmediated",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                  "defaultLiteral": "unmediated"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
             "propertyLabel": "Media type (RDA 3.2)",
@@ -20130,10 +18095,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
-              "defaultLiteral": "volume",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                  "defaultLiteral": "volume"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
             "propertyLabel": "Carrier Type (RDA 3.3)",
@@ -20146,10 +18115,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:RareMat:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
             "propertyLabel": "Extent",
@@ -20163,7 +18133,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
             "propertyLabel": "Dimensions (RDA 3.5)",
@@ -20179,7 +18150,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "LCCN"
@@ -20191,13 +18163,14 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:RareMat:RelatedInstance"
+                "profile:bf2:RelatedInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Manifestation"
+            "propertyLabel": "Related Instance"
           },
           {
             "mandatory": "false",
@@ -20209,7 +18182,8 @@
                 "profile:bf2:RareMat:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
             "propertyLabel": "Has Item"
@@ -20224,7 +18198,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
             "propertyLabel": "Administrative Metadata for Instance"
@@ -20247,8 +18222,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/heldBy",
             "propertyLabel": "Held by"
@@ -20261,7 +18240,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/sublocation",
             "propertyLabel": "Location"
@@ -20276,7 +18256,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Agents associated with Item"
@@ -20289,7 +18270,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/custodialHistory",
             "propertyLabel": "Custodial History (RDA 2.18)",
@@ -20305,7 +18287,8 @@
                 "profile:bf2:Item:ImmAcqSource"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
             "propertyLabel": "Immediate Source of Acquisition",
@@ -20321,7 +18304,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Item"
@@ -20337,7 +18321,8 @@
                 "profile:bf2:RareMat:RBMS"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Item"
@@ -20352,7 +18337,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Barcode"
@@ -20368,7 +18354,8 @@
                 "profile:bf2:Identifiers:Shelfmark"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Shelfmarks"
@@ -20385,7 +18372,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/usageAndAccessPolicy",
             "propertyLabel": "Usage and access policy"
@@ -20398,7 +18386,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/collection",
             "propertyLabel": "Collection"
@@ -20413,7 +18402,8 @@
                 "profile:bf2:Title:VarTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Item Title"
@@ -20428,7 +18418,8 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Related Works",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship"
@@ -20448,7 +18439,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
             "propertyLabel": "RBMS term"
@@ -20462,8 +18454,12 @@
               "valueTemplateRefs": [],
               "useValuesFrom": [],
               "valueDataType": {},
-              "defaultURI": "http://id.loc.gov/vocabulary/genreFormSchemes/rbmscv",
-              "defaultLiteral": "RBMS"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/genreFormSchemes/rbmscv",
+                  "defaultLiteral": "RBMS"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Source of term"
@@ -20478,48 +18474,6 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "id": "profile:bf2:RareMat:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
-          }
-        ],
-        "id": "profile:bf2:RareMat:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "target",
             "resourceTemplates": [],
             "valueConstraint": {
@@ -20528,11 +18482,12 @@
                 "http://id.loc.gov/vocabulary/millus"
               ],
               "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/Illustration",
-                "dataTypeLabelHint": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value"
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration",
+                "remark": "",
+                "dataTypeLabelHint": ""
               },
-              "valueLanguage": ""
+              "valueLanguage": "",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Illustrative Content (RDA 7.15)",
@@ -20548,7 +18503,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note about Illustrative Content"
@@ -20563,169 +18519,6 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Related Manifestations (RDA 27)",
-            "remark": "http://access.rdatoolkit.org/27.1.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
-            "propertyLabel": "Also issued in another format as:",
-            "remark": "http://access.rdatoolkit.org/J.4.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy",
-            "propertyLabel": "Accompanied by (manifestation):",
-            "remark": "http://access.rdatoolkit.org/J.4.5.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
-            "propertyLabel": "Reprinted as (manifestation):",
-            "remark": "http://access.rdatoolkit.org/J.4.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
-            "propertyLabel": "Reprint of (manifestation):",
-            "remark": "http://access.rdatoolkit.org/J.4.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
-            "propertyLabel": "Relationship Designator for Related Manifestation (RDA Appendix J)",
-            "remark": "http://access.rdatoolkit.org/J.4.html"
-          }
-        ],
-        "id": "profile:bf2:RareMat:RelatedInstance",
-        "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
-        "resourceLabel": "Related Manifestation"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:RareMat:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:RareMat:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
@@ -20735,9 +18528,10 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Search works"
           },
           {
@@ -20747,12 +18541,13 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:WorkTitle"
+                "profile:bf2:ReferenceInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/references",
             "propertyLabel": "Input work title"
           },
           {
@@ -20765,14 +18560,15 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Location of citation"
           }
         ],
         "id": "profile:bf2:RareMat:RefWork",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+        "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
         "resourceLabel": "References"
       },
       {
@@ -20780,231 +18576,23 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "resource",
+            "type": "lookup",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/works"
+                "https://lookup.ld4l.org/qa/search/linked_data/getty_aat_ld4l_cache"
               ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
-            "propertyLabel": "Lookup"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bflc:Agents:PrimaryContribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "propertyLabel": "Creator of Work (RDA 19.2)",
-            "remark": "http://access.rdatoolkit.org/19.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:WorkTitle",
-                "profile:bf2:WorkVariantTitle",
-                "profile:bflc:TranscribedTitle"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
-            "propertyLabel": "Title Information"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Agents:Contribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "propertyLabel": "Other Agent Associated with Work (RDA 19.3)",
-            "remark": "http://access.rdatoolkit.org/19.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Topic"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
-            "propertyLabel": "Subject of the Work (RDA Chapter 23)",
-            "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Form",
-                "profile:bf2:RareMat:RBMS"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
-            "propertyLabel": "Form of Work"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/maudience"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
-            "propertyLabel": "Intended Audience (RDA 7.7)",
-            "remark": "http://access.rdatoolkit.org/7.7.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Notes about the Work"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RareMat:Contents"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
-            "propertyLabel": "Contents (LC-PCC PS 25.1)"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:LCC",
-                "profile:bf2:DDC"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
-            "propertyLabel": "Classification numbers"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RareMat:Expression"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Expression elements"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RareMat:Instance"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
-            "propertyLabel": "Related Instance"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RelatedWork"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
-            "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
-            "remark": "http://access.rdatoolkit.org/6.27.1.html"
+            "propertyLabel": "Getty AAT",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/GenreForm"
           }
         ],
-        "id": "profile:bf2:RareMat:WorkOld",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
-        "resourceLabel": "BIBFRAME Work (RDA Work Elements)"
+        "id": "profile:bf2:RareMat:AAT",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
+        "resourceLabel": "Getty AAT"
       },
       {
         "propertyTemplates": [
@@ -21018,7 +18606,8 @@
                 "profile:bf2:Monograph:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Expression of"
@@ -21036,8 +18625,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
-              "defaultLiteral": "text"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                  "defaultLiteral": "text"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -21055,7 +18648,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -21071,7 +18665,8 @@
                 "profile:bf2:Language:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -21089,7 +18684,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content",
@@ -21108,7 +18704,8 @@
               "valueDataType": {
                 "dataTypeURI": ""
               },
-              "defaultURI": ""
+              "defaultURI": "",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
             "propertyLabel": "Color Content (RDA 7.17)",
@@ -21124,7 +18721,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contributor (RDA 20.2)",
@@ -21140,7 +18738,8 @@
                 "profile:bf2:RareMat:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -21155,7 +18754,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Expression"
@@ -21170,7 +18770,8 @@
                 "profile:bf2:RareMat:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content",
@@ -21186,27 +18787,246 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "lookup",
+            "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [
-                "https://lookup.ld4l.org/qa/search/linked_data/getty_aat_ld4l_cache"
+                "http://mlvlp04.loc.gov:8230/resources/works"
               ],
-              "valueDataType": {}
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+              },
+              "defaults": []
             },
-            "propertyLabel": "Getty AAT",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/GenreForm"
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
+            "propertyLabel": "Lookup"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bflc:Agents:PrimaryContribution"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+              },
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+            "propertyLabel": "Creator of Work (RDA 19.2)",
+            "remark": "http://access.rdatoolkit.org/19.2.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:WorkTitle",
+                "profile:bf2:WorkVariantTitle",
+                "profile:bflc:TranscribedTitle"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+            "propertyLabel": "Title Information"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Agents:Contribution"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
+            "propertyLabel": "Other Agent Associated with Work (RDA 19.3)",
+            "remark": "http://access.rdatoolkit.org/19.3.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Topic"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
+            "propertyLabel": "Subject of the Work (RDA Chapter 23)",
+            "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Form",
+                "profile:bf2:RareMat:RBMS"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
+            "propertyLabel": "Form of Work"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/vocabulary/maudience"
+              ],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+              },
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
+            "propertyLabel": "Intended Audience (RDA 7.7)",
+            "remark": "http://access.rdatoolkit.org/7.7.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Notes about the Work"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:RareMat:Contents"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
+            "propertyLabel": "Contents (LC-PCC PS 25.1)"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:LCC",
+                "profile:bf2:DDC"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
+            "propertyLabel": "Classification numbers"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:RareMat:Expression"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
+            "propertyLabel": "Expression elements"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:RareMat:Instance"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
+            "propertyLabel": "Related Instance"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:RelatedWork"
+              ],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+            "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
+            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "valueDataType": {},
+              "defaults": []
+            },
+            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
+            "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
+            "remark": "http://access.rdatoolkit.org/6.27.1.html"
           }
         ],
-        "id": "profile:bf2:RareMat:AAT",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/GenreForm",
-        "resourceLabel": "Getty AAT"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+        "id": "profile:bf2:RareMat:WorkOld",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
+        "resourceLabel": "BIBFRAME Work (RDA Work Elements)"
+      },
       {
         "propertyTemplates": [
           {
@@ -21221,7 +19041,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Search related works",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
@@ -21234,10 +19055,12 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Related Work Authorized Access Point",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo"
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/relatedTo",
+            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-64.html"
           },
           {
             "mandatory": "false",
@@ -21247,7 +19070,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Relationship Designator for Related Work (RDA Appendix J)",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
@@ -21263,7 +19087,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Description of Related Work"
@@ -21287,7 +19112,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Search related expressions",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
@@ -21300,10 +19126,12 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Record Related Expression Authorized Access Point",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-24.html"
           },
           {
             "mandatory": "false",
@@ -21313,7 +19141,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Relationship Designator for Related Expression  (RDA Appendix J)",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
@@ -21329,7 +19158,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Description of Related Expression"
@@ -21338,11 +19168,101 @@
         "resourceLabel": "Related Expression",
         "id": "profile:bf2:RelatedExpression",
         "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "target",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://mlvlp04.loc.gov:8230/resources/works"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
+              }
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Search related instances"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
+            "propertyLabel": "Related Instance Authorized Access Point"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "literal",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
+            "propertyLabel": "Relationship Designator for Related Instance",
+            "remark": "http://access.rdatoolkit.org/rdaappj_rdaj-15.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Description of Related Instance"
+          }
+        ],
+        "id": "profile:bf2:RelatedInstance",
+        "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
+        "resourceLabel": "Related Instance"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Title"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
+            "propertyLabel": "Title referenced"
+          }
+        ],
+        "id": "profile:bf2:ReferenceInstance",
+        "resourceLabel": "Instance Referenced",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
+        "remark": "used in rare materials profile"
+      },
       {
         "propertyTemplates": [
           {
@@ -21357,7 +19277,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Lookup"
@@ -21374,7 +19295,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -21392,7 +19314,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information (RDA 6.2.2, 6.2.3)"
@@ -21407,7 +19330,9 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work (RDA 6.3)",
@@ -21421,7 +19346,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Work (RDA 6.4)",
@@ -21437,7 +19363,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
             "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
@@ -21453,7 +19380,8 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
             "propertyLabel": "(Geographic) Coverage of the Content"
@@ -21466,7 +19394,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
@@ -21484,7 +19413,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience (RDA 7.7)",
@@ -21500,7 +19430,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -21518,7 +19449,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -21534,7 +19466,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -21550,7 +19483,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -21562,10 +19496,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Serial:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -21577,10 +19512,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Serial:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -21598,10 +19534,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
-              "defaultLiteral": "text",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                  "defaultLiteral": "text"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -21621,7 +19561,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -21637,7 +19578,8 @@
                 "profile:bf2:Script"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
             "propertyLabel": "Script (RDA 7.13.2)",
@@ -21655,7 +19597,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content (RDA 7.15)",
@@ -21668,13 +19611,15 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Serial:SupplContent"
+                "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-            "propertyLabel": "Supplementary Content"
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
+            "propertyLabel": "Color Content (RDA 7.17)",
+            "remark": "http://access.rdatoolkit.org/7.17.html"
           },
           {
             "mandatory": "false",
@@ -21683,14 +19628,14 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Note"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
-            "propertyLabel": "Color Content (RDA 7.17)",
-            "remark": "http://access.rdatoolkit.org/7.17.html"
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
+            "propertyLabel": "Supplementary Content"
           },
           {
             "mandatory": "false",
@@ -21704,7 +19649,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "repeatable": "false",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
             "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
@@ -21720,11 +19666,12 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
+            "propertyLabel": "Related Expressions",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -21736,7 +19683,8 @@
                 "profile:bf2:Serial:RelatedInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Related Manifestations (RDA Chapter 27,  Appendix J)",
@@ -21752,7 +19700,8 @@
                 "profile:bf2:Serial:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -21765,7 +19714,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
@@ -21789,7 +19739,8 @@
                 "profile:bf2:Serial:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -21810,7 +19761,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -21825,7 +19777,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
             "remark": "http://access.rdatoolkit.org/2.4.2.html",
@@ -21838,7 +19791,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -21857,7 +19811,8 @@
                 "profile:bf2:ManufactureInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -21871,7 +19826,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -21887,7 +19843,8 @@
                 "profile:bf2:SeriesInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Series Statement",
             "remark": "",
@@ -21906,10 +19863,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/serl",
-              "defaultLiteral": "serial",
               "repeatable": "true",
-              "editable": "false"
+              "editable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/serl",
+                  "defaultLiteral": "serial"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -21927,7 +19888,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Frequency",
             "remark": "",
@@ -21946,7 +19908,8 @@
                 "profile:bf2:Identifiers:Local"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -21966,10 +19929,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
-              "defaultLiteral": "unmediated",
               "repeatable": "true",
-              "editable": "false"
+              "editable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/n",
+                  "defaultLiteral": "unmediated"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.2.html"
@@ -21980,10 +19947,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Serial:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -21997,7 +19965,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -22018,10 +19987,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
               "repeatable": "true",
-              "defaultLiteral": "volume",
-              "editable": "false"
+              "editable": "false",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/nc",
+                  "defaultLiteral": "volume"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.3.html"
@@ -22036,10 +20009,11 @@
                 "profile:bf2:Serial:RelatedInstance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Manifestation (RDA 27.1)"
+            "propertyLabel": "Related Instances (RDA 27.1)"
           },
           {
             "mandatory": "false",
@@ -22051,7 +20025,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Instance",
             "remark": "http://access.rdatoolkit.org/2.17.html",
@@ -22067,7 +20042,8 @@
                 "profile:bf2:Serial:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
             "propertyLabel": "Has Item",
@@ -22081,7 +20057,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -22097,7 +20074,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
@@ -22113,7 +20091,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
             "propertyLabel": "Administrative Metadata for Instance"
@@ -22126,7 +20105,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/projectedProvisionDate",
             "remark": "http://id.loc.gov/ontologies/bflc.html#p_projectedProvisionDate",
@@ -22150,8 +20130,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -22163,7 +20147,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -22176,7 +20161,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -22191,7 +20177,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -22206,7 +20193,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -22223,7 +20211,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -22238,7 +20227,8 @@
                 "profile:bf2:Identifiers:LC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -22254,7 +20244,8 @@
                 "profile:bf2:Serial:EnumerationAndChronology"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Enumeration And Chronology of Item",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/enumerationAndChronology"
@@ -22269,7 +20260,8 @@
                 "profile:bf2:Item:ImmAcqSource"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/immediateAcquisition",
             "propertyLabel": "Immediate Acquisition"
@@ -22282,7 +20274,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/acquisitionSource",
             "remark": "http://access.rdatoolkit.org/rdachp4_rda4-93.html",
@@ -22302,7 +20295,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
             "propertyLabel": "Title Proper (RDA 2.3.2)",
@@ -22316,7 +20310,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber",
             "propertyLabel": "Designation of Part, Section or Supplement (RDA 2.3.1.7)",
@@ -22330,7 +20325,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName",
             "propertyLabel": "Title of Part, Section or Supplement (RDA 2.3.1.7)",
@@ -22340,7 +20336,7 @@
         "id": "profile:bf2:Serial:Title",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Title",
         "resourceLabel": "Title",
-        "contact": "NDMSO"
+        "author": "NDMSO"
       },
       {
         "propertyTemplates": [
@@ -22356,7 +20352,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/Relationship"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Search related works",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
@@ -22369,7 +20366,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Record Relationship Designator for Related Work (RDA Appendix J)",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
@@ -22385,7 +20383,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/absorbed",
             "propertyLabel": "Absorbed (work):",
@@ -22401,7 +20400,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Continues (work):",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/continues",
@@ -22417,7 +20417,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/continuesInPart",
             "propertyLabel": "Continues in part (work):",
@@ -22433,7 +20434,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mergerOf",
             "propertyLabel": "Merger of (work):",
@@ -22449,7 +20451,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/separatedFrom",
             "propertyLabel": "Separated from (work):",
@@ -22465,7 +20468,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Continued by (work):",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/continuedBy",
@@ -22481,7 +20485,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/absorbedBy",
             "propertyLabel": "Absorbed by (work):",
@@ -22497,7 +20502,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/continuedInPartBy",
             "propertyLabel": "Continued in part by (work):",
@@ -22513,7 +20519,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mergedToForm",
             "propertyLabel": "Merged to form (work):",
@@ -22529,7 +20536,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/splitInto",
             "propertyLabel": "Split into (work):",
@@ -22543,7 +20551,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplement",
             "propertyLabel": "Has supplement (work):"
@@ -22556,7 +20565,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementTo",
             "propertyLabel": "Supplement to (work):"
@@ -22571,7 +20581,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Description of Related Work"
@@ -22589,15 +20600,14 @@
             "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
-              "valueTemplateRefs": [
-                ""
-              ],
+              "valueTemplateRefs": [],
               "useValuesFrom": [
                 "http://mlvlp04.loc.gov:8230/resources/works"
               ],
               "valueDataType": {
-                "dataTypeURI": ""
-              }
+                "dataTypeURI": "http://id.loc.gov/ontologies/bflc/Relationship"
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Search Related Manifestation"
@@ -22610,7 +20620,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Record Related Manifestation Authorized Access Point",
@@ -22624,7 +20635,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Record Relationship Designator for Related Manifestation (RDA Appendix J)",
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relation",
@@ -22640,7 +20652,8 @@
                 "profile:bf2:Identifiers:ISSN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "ISSN of Related Manifestation"
@@ -22653,7 +20666,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Also issued in another format as:",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasEquivalent",
@@ -22667,7 +20681,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/accompaniedBy",
             "propertyLabel": "Accompanied by (manifestation):",
@@ -22683,7 +20698,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Description of Related Manifestation"
@@ -22691,7 +20707,7 @@
         ],
         "id": "profile:bf2:Serial:RelatedInstance",
         "resourceURI": "http://id.loc.gov/ontologies/bflc/Relationship",
-        "resourceLabel": "Related Manifestation"
+        "resourceLabel": "Related Instance"
       },
       {
         "propertyTemplates": [
@@ -22703,7 +20719,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/firstIssue",
             "propertyLabel": "Numeric and/or Alphabetic Designation of First Issue or Part of Sequence (RDA 2.6.2)",
@@ -22717,7 +20734,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/firstIssue",
             "propertyLabel": "Chronological Designation of First Issue or Part of Sequence (RDA 2.6.3)",
@@ -22731,7 +20749,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/lastIssue",
             "propertyLabel": "Numeric and/or Alphabetic Designation of Last Issue or Part of Sequence (RDA 2.6.4)",
@@ -22745,7 +20764,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/lastIssue",
             "propertyLabel": "Chronological Designation of Last Issue or Part of Sequence (RDA 2.6.5)",
@@ -22770,7 +20790,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Frequency"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Frequency (RDA 2.14)",
@@ -22786,7 +20807,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on Frequency (RDA 2.17.12)",
@@ -22796,120 +20818,6 @@
         "id": "profile:bf2:Serial:Frequency",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Frequency",
         "resourceLabel": "Frequency"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "id": "profile:bf2:Serial:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
-          }
-        ],
-        "id": "profile:bf2:Serial:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:Serial:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:Serial:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
       },
       {
         "id": "profile:bf2:Serial:WorkOld",
@@ -22926,7 +20834,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -22943,7 +20852,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Creator of Work (RDA 19.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -22961,7 +20871,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information (RDA 6.2.2, 6.2.3)",
@@ -22977,7 +20888,8 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.3.html",
             "mandatory": "false",
@@ -22990,7 +20902,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.4.html",
             "mandatory": "false",
@@ -23007,7 +20920,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.5.html",
             "mandatory": "false",
@@ -23022,7 +20936,8 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -23037,7 +20952,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Time) Coverage of the Content (RDA 7.3)",
@@ -23055,7 +20971,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/7.7.html",
             "mandatory": "false",
@@ -23071,7 +20988,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
             "remark": "http://access.rdatoolkit.org/19.3.html",
@@ -23087,7 +21005,8 @@
                 "profile:bf2:Topic"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
             "mandatory": "false",
@@ -23100,7 +21019,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work",
@@ -23120,7 +21040,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Classification numbers",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification"
@@ -23135,7 +21056,8 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
             "mandatory": "false",
@@ -23150,7 +21072,8 @@
                 "profile:bf2:Serial:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -23167,7 +21090,8 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html",
             "mandatory": "false",
@@ -23183,7 +21107,8 @@
                 "profile:bf2:Serial:Expression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
             "propertyLabel": "Expression elements"
@@ -23198,7 +21123,8 @@
                 "profile:bf2:Serial:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -23211,7 +21137,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Authorized Access Point Representing the Work (RDA 6.27.1)",
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
@@ -23225,7 +21152,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
             "propertyLabel": "Your Windows ID and Comments"
@@ -23248,7 +21176,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Expression of",
@@ -23267,9 +21196,13 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
               "editable": "true",
-              "defaultLiteral": "text"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/txt",
+                  "defaultLiteral": "text"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -23283,7 +21216,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Expression (RDA 6.10)",
@@ -23301,7 +21235,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -23317,7 +21252,8 @@
                 "profile:bf2:Identifiers:ISSNL"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "ISSN-L Identifier for Expression (RDA 6.13)",
@@ -23333,7 +21269,8 @@
                 "profile:bf2:Serial:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Summary",
             "remark": "",
@@ -23349,7 +21286,8 @@
                 "profile:bf2:Language:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -23363,7 +21301,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Script (RDA 7.13.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/notation",
@@ -23381,7 +21320,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Illustration"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/illustrativeContent",
             "propertyLabel": "Illustrative Content (RDA 7.15)",
@@ -23397,7 +21337,8 @@
                 "profile:bf2:Serial:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content",
@@ -23415,7 +21356,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Color Content (RDA 7.17)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/colorContent",
@@ -23431,7 +21373,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Expression",
@@ -23447,7 +21390,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "remark": "http://access.rdatoolkit.org/20.2.html",
@@ -23461,7 +21405,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Expression (RDA 6.27.3)",
@@ -23471,12 +21416,7 @@
         "id": "profile:bf2:Serial:ExpressionOld",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
         "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -23487,7 +21427,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Series Statement and ISSN of Series (RDA 2.12.1-2.12.8)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesStatement",
@@ -23501,7 +21442,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/seriesEnumeration",
             "propertyLabel": "Series Numbering (RDA 2.12.9)",
@@ -23515,7 +21457,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subseriesStatement",
             "propertyLabel": "Subseries Title Proper, ISSN of Subseries (RDA 2.12.10-2.12.16)",
@@ -23529,22 +21472,35 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subseriesEnumeration",
             "propertyLabel": "Numbering within Subseries (RDA 2.12.17)",
             "remark": "http://access.rdatoolkit.org/2.12.17.html"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Note"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
+            "propertyLabel": "Note about the series"
           }
         ],
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance",
         "id": "profile:bf2:SeriesInformation",
         "resourceLabel": "Series Statement",
         "remark": "http://access.rdatoolkit.org/rdachp2_rda2-7632.html"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -23559,7 +21515,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Lookup"
@@ -23576,7 +21533,9 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -23594,7 +21553,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
@@ -23609,7 +21569,9 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -23626,7 +21588,8 @@
                 "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
                 "dataTypeLabel": "EDTF",
                 "dataTypeLabelHint": "ISO"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Work (RDA 6.4)",
@@ -23642,7 +21605,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
             "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
@@ -23655,10 +21619,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:MOPStatement"
+                "profile:bf2:MOPStatement"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
             "propertyLabel": "Medium of Performance Statement"
@@ -23673,7 +21638,8 @@
                 "profile:bf2:PMOMedPerf:PerfMed"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Performed Medium",
             "propertyURI": "http://performedmusicontology.org/ontology/hasMedium"
@@ -23685,10 +21651,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:MedPerfInst"
+                "profile:bf2:MOPInstrument"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -23700,10 +21667,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:MedPerfVoice"
+                "profile:bf2:MOPVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -23715,10 +21683,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:MedPerfEnsemble"
+                "profile:bf2:MOPEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -23731,7 +21700,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber",
             "propertyLabel": "Music Serial Number (RDA 6.16.1.3.1)",
@@ -23745,7 +21715,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicOpusNumber",
             "propertyLabel": "Music Opus Number (RDA 6.16.1.3.2)",
@@ -23759,7 +21730,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicThematicNumber",
             "propertyLabel": "Thematic Index Number (RDA 6.16.1.3.3)",
@@ -23773,7 +21745,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
             "propertyLabel": "Key (RDA 6.17)",
@@ -23789,7 +21762,9 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
             "propertyLabel": "(Geographic) Coverage of the Content"
@@ -23802,7 +21777,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
@@ -23820,7 +21796,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience (RDA 7.7)",
@@ -23836,7 +21813,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -23854,7 +21833,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -23870,7 +21850,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -23882,10 +21863,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -23897,10 +21879,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -23918,10 +21901,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
-              "defaultLiteral": "performed music",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                  "defaultLiteral": "performed music"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -23941,7 +21928,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -23957,7 +21945,8 @@
                 "profile:bf2:Identifiers:Matrix"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
             "propertyLabel": "Identifiers"
@@ -23969,10 +21958,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:Capture"
+                "profile:bf2:Capture"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
             "propertyLabel": "Capture information"
@@ -23984,10 +21974,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -24000,7 +21991,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -24016,11 +22008,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -24032,11 +22025,12 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
+            "propertyLabel": "Related Expressions",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -24045,10 +22039,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:Instance2"
+                "profile:bf2:Analog:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -24061,7 +22056,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
@@ -24071,683 +22067,6 @@
         "id": "profile:bf2:Analog:Work",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
         "resourceLabel": "BIBFRAME Work"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/works"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
-            "propertyLabel": "Search Existing RDA/BIBFRAME Work"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Preferred Title + AAP Expression Elements"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/contentTypes"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
-              "defaultLiteral": "performed music"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
-            "propertyLabel": "Content Type (RDA 6.9)",
-            "remark": "http://access.rdatoolkit.org/6.9.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Language2"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
-            "propertyLabel": "Language",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:Matrix"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "propertyLabel": "Identifier"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Summary"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
-            "propertyLabel": "Summary"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Capture"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
-            "propertyLabel": "Capture information"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:SupplContent"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-            "propertyLabel": "Supplementary Content"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
-            "propertyLabel": "Duration (RDA 7.22)",
-            "remark": "http://access.rdatoolkit.org/7.22.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Agents:Contribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
-            "propertyLabel": "Contributor (RDA 20.2)",
-            "remark": "http://access.rdatoolkit.org/20.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Notes about the Expression"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:MOPStatement"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
-            "propertyLabel": "Medium of Performance Statement"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:MedPerfInst"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
-            "propertyLabel": "Medium of Performance - Instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:MedPerfVoice"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
-            "propertyLabel": "Medium of Performance - Voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:MedPerfEnsemble"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
-            "propertyLabel": "Medium of Performance - Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RelatedWork"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:RelatedExpression"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Instance2"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
-            "propertyLabel": "Has BIBFRAME Instance"
-          }
-        ],
-        "id": "profile:bf2:Analog:Expression",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
-        "resourceLabel": "Search Existing Work and Add Expression Elements to Create New Work (unused)"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Title",
-                "profile:bf2:Title:VarTitle",
-                "profile:bf2:ParallelTitle",
-                "profile:bflc:TranscribedTitle"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
-            "propertyLabel": "Title Information (RDA 2.3)"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
-            "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
-            "remark": "http://access.rdatoolkit.org/2.4.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/editionStatement",
-            "propertyLabel": "Edition Statement (RDA 2.5)",
-            "remark": "http://access.rdatoolkit.org/2.5.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:PublicationInformation",
-                "profile:bf2:ManufactureInformation",
-                "profile:bf2:DistributionInformation"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/provisionActivity",
-            "propertyLabel": "Publication, Distribution, Manufacture Statements"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
-            "propertyLabel": "Copyright Date (RDA 2.11)",
-            "remark": "http://access.rdatoolkit.org/2.11.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SeriesInformation"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasSeries",
-            "propertyLabel": "Series Statement"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/issuance"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
-            "propertyLabel": "Mode of Issuance (RDA 2.13)",
-            "remark": "http://access.rdatoolkit.org/2.13.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:ISBN",
-                "profile:bf2:Identifiers:ISMN",
-                "profile:bf2:Identifiers:PubNumber",
-                "profile:bf2:Identifiers:EAN",
-                "profile:bf2:Identifiers:UPC",
-                "profile:bf2:TestProfile:ISRC",
-                "profile:bf2:Identifiers:Copyright",
-                "profile:bf2:Identifiers:Other",
-                "profile:bf2:Identifiers:Local"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "propertyLabel": "Identifiers"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Notes about the Instance",
-            "remark": "http://access.rdatoolkit.org/2.17.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Credits"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/credits",
-            "propertyLabel": "Credits",
-            "remark": "http://access.rdatoolkit.org/2.17.3.5.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mediaTypes"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
-              "defaultLiteral": "audio"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/media",
-            "propertyLabel": "Media type (RDA 3.2)",
-            "remark": "http://access.rdatoolkit.org/3.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/carriers"
-              ],
-              "valueDataType": {},
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
-              "defaultLiteral": "audio disc"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/carrier",
-            "propertyLabel": "Carrier Type (RDA 3.3)",
-            "remark": "http://access.rdatoolkit.org/3.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Extent"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/extent",
-            "propertyLabel": "Extent"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/dimensions",
-            "propertyLabel": "Dimensions (RDA 3.5)",
-            "remark": "http://access.rdatoolkit.org/3.5.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mmaterial"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/BaseMaterial"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/baseMaterial",
-            "propertyLabel": "Base Material (RDA 3.6)",
-            "remark": "http://access.rdatoolkit.org/3.6.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mmaterial"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/appliedMaterial",
-            "propertyLabel": "Applied Material (RDA 3.7)",
-            "remark": "http://access.rdatoolkit.org/3.7.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Production"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
-            "propertyLabel": "Production Method"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mgeneration"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Generation"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/generation",
-            "propertyLabel": "Recording Generation (RDA 3.10)",
-            "remark": "http://access.rdatoolkit.org/3.10.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Sound1",
-                "profile:bf2:Analog:Sound2",
-                "profile:bf2:Analog:Sound3",
-                "profile:bf2:Analog:Sound6",
-                "profile:bf2:Analog:Sound4",
-                "profile:bf2:Analog:Sound5"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundCharacteristic",
-            "propertyLabel": "Sound Characteristics"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/electronicLocator",
-            "propertyLabel": "Uniform Resource Locator (RDA 4.6)",
-            "remark": "http://access.rdatoolkit.org/4.6.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Identifiers:LCCN"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
-            "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
-            "remark": "http://access.rdatoolkit.org/2.15.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:AdminMetadata"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata",
-            "propertyLabel": "Administrative Metadata for Instance"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Item"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
-            "propertyLabel": "Has Item"
-          }
-        ],
-        "id": "profile:bf2:Analog:Instance2",
-        "resourceLabel": "Add BIBFRAME Instance",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Instance"
       },
       {
         "id": "profile:bf2:Analog:Instance",
@@ -24764,7 +22083,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -24783,7 +22103,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -24798,7 +22119,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
             "remark": "http://access.rdatoolkit.org/2.4.2.html",
@@ -24813,7 +22135,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -24832,7 +22155,8 @@
                 "profile:bf2:DistributionInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -24846,7 +22170,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -24862,7 +22187,8 @@
                 "profile:bf2:SeriesInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Series Statement",
             "remark": "",
@@ -24882,9 +22208,13 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
               "editable": "false",
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -24902,13 +22232,15 @@
                 "profile:bf2:Identifiers:PubNumber",
                 "profile:bf2:Identifiers:EAN",
                 "profile:bf2:Identifiers:UPC",
-                "profile:bf2:TestProfile:ISRC",
+                "profile:bf2:Identifiers:ISRC",
                 "profile:bf2:Identifiers:Copyright",
                 "profile:bf2:Identifiers:Other",
-                "profile:bf2:Identifiers:Local"
+                "profile:bf2:Identifiers:Local",
+                "profile:bf2:Identifiers:AudioIssue"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -24924,7 +22256,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Instance",
             "remark": "http://access.rdatoolkit.org/2.17.html",
@@ -24940,7 +22273,8 @@
                 "profile:bf2:Analog:Credits"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Credits",
             "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
@@ -24960,10 +22294,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
-              "defaultLiteral": "audio",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
+                  "defaultLiteral": "audio"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.2.html"
@@ -24982,10 +22320,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
-              "defaultLiteral": "audio disc",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
+                  "defaultLiteral": "audio disc"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.3.html"
@@ -24996,10 +22338,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -25021,7 +22364,8 @@
               "defaultLiteral": "",
               "editable": "true",
               "repeatable": "false",
-              "defaultURI": ""
+              "defaultURI": "",
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "false",
@@ -25043,7 +22387,8 @@
               },
               "editable": "true",
               "defaultLiteral": "",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyLabel": "Base Material (RDA 3.6)",
             "remark": "http://access.rdatoolkit.org/3.6.html",
@@ -25061,7 +22406,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Applied Material (RDA 3.7)",
             "remark": "http://access.rdatoolkit.org/3.7.html",
@@ -25074,10 +22420,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:Production"
+                "profile:bf2:ProdMeth"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
             "propertyLabel": "Production Method",
@@ -25095,7 +22442,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Generation"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Recording Generation (RDA 3.10)",
             "remark": "http://access.rdatoolkit.org/3.10.html",
@@ -25108,19 +22456,20 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:Analog:Sound1",
-                "profile:bf2:Analog:Sound2",
-                "profile:bf2:Analog:Sound3",
+                "profile:bf2:TypeRec",
+                "profile:bf2:RecMedium",
+                "profile:bf2:PlayingSpeed",
                 "profile:bf2:Analog:Sound6",
-                "profile:bf2:Analog:Sound4",
-                "profile:bf2:Analog:Sound5"
+                "profile:bf2:Playback",
+                "profile:bf2:SpecPlayback"
               ],
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabelHint": ""
               },
               "editable": "false",
-              "defaultLiteral": ""
+              "defaultLiteral": "",
+              "defaults": []
             },
             "propertyLabel": "Sound Characteristics",
             "remark": "",
@@ -25134,7 +22483,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -25150,7 +22500,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
@@ -25166,7 +22517,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Administrative Metadata for Instance",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
@@ -25181,7 +22533,8 @@
                 "profile:bf2:Analog:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
             "propertyLabel": "Has Item"
@@ -25204,8 +22557,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -25219,7 +22576,8 @@
                 "profile:bf2:Identifiers:Shelfmark"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -25234,7 +22592,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -25247,7 +22606,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -25260,7 +22620,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -25275,7 +22636,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -25292,7 +22654,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -25312,49 +22675,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Credits note"
@@ -25363,439 +22685,6 @@
         "id": "profile:bf2:Analog:Credits",
         "resourceLabel": "Credits note",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrumentalType",
-            "propertyLabel": "Type of instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:Analog:MedPerfInst",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument",
-        "resourceLabel": "Instrument"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/voiceType",
-            "propertyLabel": "Type of voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:Analog:MedPerfVoice",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice",
-        "resourceLabel": "Voice"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensembleType",
-            "propertyLabel": "Type of Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:Analog:MedPerfEnsemble",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble",
-        "resourceLabel": "Ensemble"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Analog:Place"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
-            "propertyLabel": "Place of Capture (RDA 7.11.2)",
-            "remark": "http://access.rdatoolkit.org/7.11.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
-            "propertyLabel": "Date of Capture (RDA 7.11.3)",
-            "remark": "http://access.rdatoolkit.org/7.11.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Capture note"
-          }
-        ],
-        "id": "profile:bf2:Analog:Capture",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Capture",
-        "resourceLabel": "Capture information"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
-              }
-            },
-            "propertyLabel": "Place",
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
-          }
-        ],
-        "id": "profile:bf2:Analog:Place",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
-        "resourceLabel": "Place"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mproduction"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Production Method (RDA 3.9.1.3)",
-            "remark": "http://access.rdatoolkit.org/3.9.1.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Details of Production Method (RDA 3.9.1.4)",
-            "remark": "http://access.rdatoolkit.org/3.9.1.4.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          }
-        ],
-        "id": "profile:bf2:Analog:Production",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod",
-        "resourceLabel": "Production Method"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrectype"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/RecordingMethod"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/mrectype/analog",
-              "defaultLiteral": "analog"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Type of Recording (RDA 3.16.2)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Type of Recording (RDA 3.16.2.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.4.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Sound1",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod",
-        "resourceLabel": "Type of Recording"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrecmedium"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/RecordingMedium",
-                "dataTypeLabelHint": ""
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/mrecmedium/mag",
-              "defaultLiteral": "magnetic"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Recording Medium (RDA 3.16.3)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Recording Medium (RDA 3.16.3.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.4.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Sound2",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium",
-        "resourceLabel": "Recording Medium"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Playing Speed (RDA 3.16.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.4.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Sound3",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlayingSpeed",
-        "resourceLabel": "Playing Speed"
       },
       {
         "propertyTemplates": [
@@ -25810,9 +22699,10 @@
                 "http://id.loc.gov/vocabulary/mgroove"
               ],
               "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/GrooveCharacteristic"
-              }
+                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/GrooveCharacteristic",
+                "remark": ""
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Groove Characteristic (RDA 3.16.5)",
@@ -25828,7 +22718,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Details of Groove Characteristic (RDA 3.16.5.4)",
@@ -25838,258 +22729,6 @@
         "id": "profile:bf2:Analog:Sound6",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/GrooveCharacteristic",
         "resourceLabel": "Groove Characteristic"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Configuration of Playback Channels (RDA 3.16.8)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Configuration of Playback Channels (RDA 3.16.8.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.4.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Sound4",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels",
-        "resourceLabel": "Playback Channels"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mspecplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Special Playback Characteristic (RDA 3.16.9)",
-            "remark": "http://access.rdatoolkit.org/3.16.9.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Sound5",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic",
-        "resourceLabel": "Special Playback Characteristic"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mfiletype"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/FileType"
-              },
-              "defaultURI": "http://id.loc.gov/vocabulary/mfiletype/audio",
-              "defaultLiteral": "audio file"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "File Type (RDA 3.19)",
-            "remark": "http://access.rdatoolkit.org/3.19.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Digital",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileType",
-        "resourceLabel": "File type"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Encoding Format (RDA 3.19.3)",
-            "remark": "http://access.rdatoolkit.org/3.19.3.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Digital1",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/EncodingFormat",
-        "resourceLabel": "Encoding format"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "File Size (RDA 3.19.4)",
-            "remark": "http://access.rdatoolkit.org/3.19.4.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:Digital2",
-        "resourceLabel": "File size",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileSize"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:Analog:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "System Requirement (RDA 3.20)",
-            "remark": "http://access.rdatoolkit.org/3.20.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:SysReq",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SystemRequirement",
-        "resourceLabel": "System Requirement"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:Analog:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Medium of Performance (RDA 7.21)",
-            "remark": "http://access.rdatoolkit.org/7.21.html"
-          }
-        ],
-        "id": "profile:bf2:Analog:MOPStatement",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
-        "resourceLabel": "Medium of Performance Statement"
       },
       {
         "id": "profile:bf2:Analog:WorkOld",
@@ -26107,7 +22746,8 @@
               "valueTemplateRefs": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -26124,7 +22764,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Creator of Work (RDA 19.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -26142,7 +22783,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -26158,7 +22800,8 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -26176,7 +22819,8 @@
                 "dataTypeLabel": "EDTF",
                 "dataTypeLabelHint": "ISO",
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.4.html",
             "mandatory": "false",
@@ -26193,7 +22837,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.5.html",
             "mandatory": "false",
@@ -26211,7 +22856,8 @@
               ],
               "useValuesFrom": [],
               "valueDataType": {},
-              "editable": "false"
+              "editable": "false",
+              "defaults": []
             },
             "propertyLabel": "Medium of Performance (RDA 6.15)",
             "remark": "http://access.rdatoolkit.org/6.15.html",
@@ -26227,7 +22873,8 @@
                 "profile:bf2:Analog:MedPerfInst"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -26242,7 +22889,8 @@
                 "profile:bf2:Analog:MedPerfVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -26257,7 +22905,8 @@
                 "profile:bf2:Analog:MedPerfEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -26270,7 +22919,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Numerical Designation of a Musical Work (RDA 6.16)",
             "remark": "http://access.rdatoolkit.org/6.16.html",
@@ -26284,7 +22934,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Key (RDA 6.17)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
@@ -26299,7 +22950,8 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -26314,7 +22966,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
@@ -26332,7 +22985,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/7.7.html",
             "mandatory": "false",
@@ -26348,7 +23002,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
             "remark": "http://access.rdatoolkit.org/19.3.html",
@@ -26364,7 +23019,8 @@
                 "profile:bf2:Topic"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
             "mandatory": "false",
@@ -26377,7 +23033,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work",
@@ -26397,7 +23054,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -26412,7 +23070,8 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
             "mandatory": "false",
@@ -26427,7 +23086,8 @@
                 "profile:bf2:Analog:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -26444,7 +23104,8 @@
                 "profile:bf2:Analog:Expression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -26458,7 +23119,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
@@ -26472,7 +23134,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
             "propertyLabel": "Your Windows ID and Comments"
@@ -26487,7 +23150,8 @@
                 "profile:bf2:Analog:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -26511,7 +23175,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Expression of",
@@ -26527,7 +23192,8 @@
                 "profile:bf2:Analog:MedPerfInst"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -26542,7 +23208,8 @@
                 "profile:bf2:Analog:MedPerfVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -26557,7 +23224,8 @@
                 "profile:bf2:Analog:MedPerfEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -26577,9 +23245,13 @@
                 "dataTypeLabel": ""
               },
               "editable": "true",
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
-              "defaultLiteral": "performed music",
-              "remark": ""
+              "remark": "",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                  "defaultLiteral": "performed music"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -26593,7 +23265,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Date of Expression (RDA 6.10)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
@@ -26611,7 +23284,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -26627,7 +23301,8 @@
                 "profile:bf2:Identifiers:Matrix"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Identifier for the Expression",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy"
@@ -26642,7 +23317,8 @@
                 "profile:bf2:Analog:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary",
@@ -26658,7 +23334,8 @@
                 "profile:bf2:Analog:Capture"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Capture information",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture"
@@ -26675,7 +23352,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/vocabulary/languages"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -26691,7 +23369,8 @@
                 "profile:bf2:Analog:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content",
@@ -26707,7 +23386,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -26723,7 +23403,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Contributor (RDA 20.2)",
             "remark": "http://access.rdatoolkit.org/20.2.html",
@@ -26739,7 +23420,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Expression",
             "remark": "",
@@ -26753,7 +23435,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Musical Expression (RDA 6.28.3)",
@@ -26763,12 +23446,7 @@
         "id": "profile:bf2:Analog:ExpressionOld",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
         "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -26783,7 +23461,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Lookup"
@@ -26800,7 +23479,9 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -26818,7 +23499,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
@@ -26833,7 +23515,9 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -26850,7 +23534,8 @@
                 "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
                 "dataTypeLabel": "EDTF",
                 "dataTypeLabelHint": "ISO"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Work (RDA 6.4)",
@@ -26866,7 +23551,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
             "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
@@ -26879,10 +23565,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:MOPStatement"
+                "profile:bf2:MOPStatement"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
             "propertyLabel": "Medium of Performance Statement"
@@ -26897,7 +23584,8 @@
                 "profile:bf2:PMOMedPerf:PerfMed"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
             "propertyLabel": "Performed Medium"
@@ -26909,10 +23597,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:MedPerfInst"
+                "profile:bf2:MOPInstrument"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -26924,10 +23613,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:MedPerfVoice"
+                "profile:bf2:MOPVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -26939,10 +23629,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:MedPerfEnsemble"
+                "profile:bf2:MOPEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -26955,7 +23646,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber",
             "propertyLabel": "Music Serial Number (RDA 6.16.1.3.1)",
@@ -26969,7 +23661,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicOpusNumber",
             "propertyLabel": "Music Opus Number (RDA 6.16.1.3.2)",
@@ -26983,7 +23676,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicThematicNumber",
             "propertyLabel": "Thematic Index Number (RDA 6.16.1.3.3)",
@@ -26997,7 +23691,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
             "propertyLabel": "Key (RDA 6.17)",
@@ -27013,7 +23708,9 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
             "propertyLabel": "(Geographic) Coverage of the Content"
@@ -27026,7 +23723,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
@@ -27046,7 +23744,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience (RDA 7.7)",
@@ -27062,7 +23761,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -27080,7 +23781,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -27096,7 +23798,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -27108,10 +23811,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -27123,10 +23827,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -27144,10 +23849,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
-              "defaultLiteral": "performed music",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                  "defaultLiteral": "performed music"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -27167,7 +23876,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -27180,10 +23890,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:Capture"
+                "profile:bf2:Capture"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
             "propertyLabel": "Capture information"
@@ -27195,10 +23906,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -27211,7 +23923,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -27227,11 +23940,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -27243,11 +23957,12 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
+            "propertyLabel": "Related Expressions",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -27259,7 +23974,8 @@
                 "profile:bf2:SoundCDR:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -27272,7 +23988,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
@@ -27298,7 +24015,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -27317,7 +24035,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27332,7 +24051,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
             "remark": "http://access.rdatoolkit.org/2.4.2.html",
@@ -27347,7 +24067,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27366,7 +24087,8 @@
                 "profile:bf2:DistributionInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27382,7 +24104,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -27398,7 +24121,8 @@
                 "profile:bf2:SeriesInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Series Statement",
             "remark": "",
@@ -27418,9 +24142,13 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
               "editable": "false",
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -27438,13 +24166,15 @@
                 "profile:bf2:Identifiers:PubNumber",
                 "profile:bf2:Identifiers:EAN",
                 "profile:bf2:Identifiers:UPC",
-                "profile:bf2:TestProfile:ISRC",
+                "profile:bf2:Identifiers:ISRC",
                 "profile:bf2:Identifiers:Copyright",
                 "profile:bf2:Identifiers:Other",
-                "profile:bf2:Identifiers:Local"
+                "profile:bf2:Identifiers:Local",
+                "profile:bf2:Identifiers:AudioIssue"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27460,7 +24190,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Instance",
             "remark": "http://access.rdatoolkit.org/2.17.html",
@@ -27476,7 +24207,8 @@
                 "profile:bf2:SoundCDR:Credits"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Credits",
             "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
@@ -27496,10 +24228,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
-              "defaultLiteral": "audio",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
+                  "defaultLiteral": "audio"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.2.html"
@@ -27518,10 +24254,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
-              "defaultLiteral": "audio disc",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
+                  "defaultLiteral": "audio disc"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.3.html"
@@ -27532,10 +24272,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27557,7 +24298,8 @@
               "defaultLiteral": "",
               "editable": "true",
               "repeatable": "false",
-              "defaultURI": ""
+              "defaultURI": "",
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "false",
@@ -27579,7 +24321,8 @@
               },
               "editable": "true",
               "defaultLiteral": "",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyLabel": "Base Material (RDA 3.6)",
             "remark": "http://access.rdatoolkit.org/3.6.html",
@@ -27597,7 +24340,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Applied Material (RDA 3.7)",
             "remark": "http://access.rdatoolkit.org/3.7.html",
@@ -27610,10 +24354,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:Production"
+                "profile:bf2:ProdMeth"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/productionMethod",
             "propertyLabel": "Production Method",
@@ -27631,7 +24376,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Generation"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Recording Generation (RDA 3.10)",
             "remark": "http://access.rdatoolkit.org/3.10.html",
@@ -27644,18 +24390,19 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:Sound1",
-                "profile:bf2:SoundCDR:Sound2",
-                "profile:bf2:SoundCDR:Sound3",
-                "profile:bf2:SoundCDR:Sound4",
-                "profile:bf2:SoundCDR:Sound5"
+                "profile:bf2:TypeRec",
+                "profile:bf2:RecMedium",
+                "profile:bf2:PlayingSpeed",
+                "profile:bf2:Playback",
+                "profile:bf2:SpecPlayback"
               ],
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabelHint": ""
               },
               "editable": "false",
-              "defaultLiteral": ""
+              "defaultLiteral": "",
+              "defaults": []
             },
             "propertyLabel": "Sound Characteristics",
             "remark": "",
@@ -27668,16 +24415,17 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:Digital",
-                "profile:bf2:SoundCDR:Digital1",
-                "profile:bf2:SoundCDR:Digital2"
+                "profile:bf2:FileType",
+                "profile:bf2:EncFmt",
+                "profile:bf2:FileSize"
               ],
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeLabelHint": ""
               },
               "editable": "true",
-              "defaultLiteral": ""
+              "defaultLiteral": "",
+              "defaults": []
             },
             "propertyLabel": "Digital Characteristics",
             "remark": "",
@@ -27690,10 +24438,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:SysReq"
+                "profile:bf2:SysReq"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/systemRequirement",
             "propertyLabel": "System Requirement"
@@ -27706,7 +24455,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27722,7 +24472,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
@@ -27738,7 +24489,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Administrative Metadata for Instance",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
@@ -27753,7 +24505,8 @@
                 "profile:bf2:SoundCDR:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
             "propertyLabel": "Has Item"
@@ -27776,8 +24529,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -27791,7 +24548,8 @@
                 "profile:bf2:Identifiers:Shelfmark"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27806,7 +24564,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27819,7 +24578,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27832,7 +24592,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27847,7 +24608,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27864,7 +24626,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -27884,49 +24647,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Credits note"
@@ -27935,685 +24657,6 @@
         "id": "profile:bf2:SoundCDR:Credits",
         "resourceLabel": "Credits note",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrumentalType",
-            "propertyLabel": "Type of instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:MedPerfInst",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument",
-        "resourceLabel": "Instrument"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/voiceType",
-            "propertyLabel": "Type of voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:MedPerfVoice",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice",
-        "resourceLabel": "Voice"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensembleType",
-            "propertyLabel": "Type of Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:MedPerfEnsemble",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble",
-        "resourceLabel": "Ensemble"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SoundCDR:Place"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
-            "propertyLabel": "Place of Capture (RDA 7.11.2)",
-            "remark": "http://access.rdatoolkit.org/7.11.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
-            "propertyLabel": "Date of Capture (RDA 7.11.3)",
-            "remark": "http://access.rdatoolkit.org/7.11.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Capture note"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Capture",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Capture",
-        "resourceLabel": "Capture information"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
-              }
-            },
-            "propertyLabel": "Place",
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Place",
-        "resourceLabel": "Place",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mproduction"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/ProductionMethod"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Production Method (RDA 3.9.1.3)",
-            "remark": "http://access.rdatoolkit.org/3.9.1.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Details of Production Method (RDA 3.9.1.4)",
-            "remark": "http://access.rdatoolkit.org/3.9.1.4.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Production",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/ProductionMethod",
-        "resourceLabel": "Production Method"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrectype"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/RecordingMethod"
-              },
-              "defaultURI": ""
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Type of Recording (RDA 3.16.2)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Type of Recording (RDA 3.16.2.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Sound1",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod",
-        "resourceLabel": "Type of Recording"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrecmedium"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/RecordingMedium"
-              }
-            },
-            "propertyURI": "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
-            "propertyLabel": "Recording Medium (RDA 3.16.3)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Recording Medium (RDA 3.16.3.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Sound2",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium",
-        "resourceLabel": "Recording Medium"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Playing Speed (RDA 3.16.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Sound3",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlayingSpeed",
-        "resourceLabel": "Playing Speed"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Configuration of Playback Channels (RDA 3.16.8)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Configuration of Playback Channels (RDA 3.16.8.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Sound4",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels",
-        "resourceLabel": "Playback Channels"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mspecplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Special Playback Characteristic (RDA 3.16.9)",
-            "remark": "http://access.rdatoolkit.org/3.16.9.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Sound5",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic",
-        "resourceLabel": "Special Playback Characteristic"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mfiletype"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/FileType"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "File Type (RDA 3.19)",
-            "remark": "http://access.rdatoolkit.org/3.19.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Digital",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileType",
-        "resourceLabel": "File type"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Encoding Format (RDA 3.19.3)",
-            "remark": "http://access.rdatoolkit.org/3.19.3.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Digital1",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/EncodingFormat",
-        "resourceLabel": "Encoding format"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "File Size (RDA 3.19.4)",
-            "remark": "http://access.rdatoolkit.org/3.19.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Digital2",
-        "resourceLabel": "File size",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileSize"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "System Requirement (RDA 3.20)",
-            "remark": "http://access.rdatoolkit.org/3.20.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:SysReq",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SystemRequirement",
-        "resourceLabel": "System Requirement"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Medium of Performance (RDA 7.21)",
-            "remark": "http://access.rdatoolkit.org/7.21.html"
-          }
-        ],
-        "id": "profile:bf2:SoundCDR:MOPStatement",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
-        "resourceLabel": "Medium of Performance Statement"
       },
       {
         "id": "profile:bf2:SoundCDR:WorkOld",
@@ -28631,7 +24674,8 @@
               "valueTemplateRefs": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -28648,7 +24692,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Creator of Work (RDA 19.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -28666,7 +24711,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -28682,7 +24728,8 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -28700,7 +24747,8 @@
                 "dataTypeLabel": "EDTF",
                 "dataTypeLabelHint": "ISO",
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.4.html",
             "mandatory": "false",
@@ -28717,7 +24765,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.5.html",
             "mandatory": "false",
@@ -28735,7 +24784,8 @@
               ],
               "useValuesFrom": [],
               "valueDataType": {},
-              "editable": "false"
+              "editable": "false",
+              "defaults": []
             },
             "propertyLabel": "Medium of Performance (RDA 6.15)",
             "remark": "http://access.rdatoolkit.org/6.15.html",
@@ -28751,7 +24801,8 @@
                 "profile:bf2:SoundCDR:MedPerfInst"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -28766,7 +24817,8 @@
                 "profile:bf2:SoundCDR:MedPerfVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -28781,7 +24833,8 @@
                 "profile:bf2:SoundCDR:MedPerfEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -28794,7 +24847,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Numerical Designation of a Musical Work (RDA 6.16)",
             "remark": "http://access.rdatoolkit.org/6.16.html",
@@ -28808,7 +24862,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Key (RDA 6.17)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
@@ -28823,7 +24878,8 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -28838,7 +24894,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
@@ -28856,7 +24913,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/7.7.html",
             "mandatory": "false",
@@ -28872,7 +24930,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
             "remark": "http://access.rdatoolkit.org/19.3.html",
@@ -28888,7 +24947,8 @@
                 "profile:bf2:Topic"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
             "mandatory": "false",
@@ -28901,7 +24961,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work",
@@ -28921,7 +24982,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -28936,7 +24998,8 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
             "mandatory": "false",
@@ -28951,7 +25014,8 @@
                 "profile:bf2:SoundCDR:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -28968,7 +25032,8 @@
                 "profile:bf2:SoundRecording:Expression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -28982,7 +25047,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
@@ -28996,7 +25062,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
             "propertyLabel": "Your Windows ID and Comments"
@@ -29011,7 +25078,8 @@
                 "profile:bf2:SoundRecording:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -29035,7 +25103,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
             "propertyLabel": "Expression of",
@@ -29051,7 +25120,8 @@
                 "profile:bf2:SoundCDR:MedPerfInst"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -29066,7 +25136,8 @@
                 "profile:bf2:SoundCDR:MedPerfVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -29081,7 +25152,8 @@
                 "profile:bf2:SoundCDR:MedPerfEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -29101,9 +25173,13 @@
                 "dataTypeLabel": ""
               },
               "editable": "true",
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
-              "defaultLiteral": "performed music",
-              "remark": ""
+              "remark": "",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                  "defaultLiteral": "performed music"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -29117,7 +25193,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Date of Expression (RDA 6.10)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
@@ -29135,7 +25212,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Expression (RDA 6.11)",
@@ -29151,7 +25229,8 @@
                 "profile:bf2:SoundCDR:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary",
@@ -29167,7 +25246,8 @@
                 "profile:bf2:SoundCDR:Capture"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Capture information",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture"
@@ -29184,7 +25264,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/vocabulary/languages"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language of Content (RDA 7.12)",
@@ -29200,7 +25281,8 @@
                 "profile:bf2:SoundCDR:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content",
@@ -29216,7 +25298,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -29232,7 +25315,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Contributor (RDA 20.2)",
             "remark": "http://access.rdatoolkit.org/20.2.html",
@@ -29248,7 +25332,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Expression",
             "remark": "",
@@ -29262,7 +25347,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Musical Expression (RDA 6.28.3)",
@@ -29272,12 +25358,7 @@
         "id": "profile:bf2:SoundCDR:ExpressionOld",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
         "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -29292,7 +25373,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/Work",
             "propertyLabel": "Lookup"
@@ -29309,7 +25391,9 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Creator of Work (RDA 19.2)",
@@ -29327,7 +25411,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/title",
             "propertyLabel": "Title Information (RDA 6.14.2, RDA 6.14.3)"
@@ -29342,7 +25427,9 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/genreForm",
             "propertyLabel": "Form of Work"
@@ -29359,7 +25446,8 @@
                 "dataTypeURI": "http://www.loc.gov/standards/datetime/pre-submission.html",
                 "dataTypeLabel": "EDTF",
                 "dataTypeLabelHint": "ISO"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
             "propertyLabel": "Date of Work (RDA 6.4)",
@@ -29375,7 +25463,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/originPlace",
             "propertyLabel": "Place of Origin of the Work (RDA 6.5)",
@@ -29388,10 +25477,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:MOPStatement"
+                "profile:bf2:MOPStatement"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicMedium",
             "propertyLabel": "Medium of Performance Statement"
@@ -29406,7 +25496,8 @@
                 "profile:bf2:PMOMedPerf:PerfMed"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMedium",
             "propertyLabel": "Performed Medium"
@@ -29418,10 +25509,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:MedPerfInst"
+                "profile:bf2:MOPInstrument"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -29433,10 +25525,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:MedPerfVoice"
+                "profile:bf2:MOPVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -29448,10 +25541,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:MedPerfEnsemble"
+                "profile:bf2:MOPEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -29464,7 +25558,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicSerialNumber",
             "propertyLabel": "Music Serial Number (RDA 6.16.1.3.1)",
@@ -29478,7 +25573,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicOpusNumber",
             "propertyLabel": "Music Opus Number (RDA 6.16.1.3.2)",
@@ -29492,7 +25588,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicThematicNumber",
             "propertyLabel": "Thematic Index Number (RDA 6.16.1.3.3)",
@@ -29506,7 +25603,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
             "propertyLabel": "Key (RDA 6.17)",
@@ -29522,7 +25620,9 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/geographicCoverage",
             "propertyLabel": "(Geographic) Coverage of the Content"
@@ -29535,7 +25635,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
@@ -29553,7 +25654,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/intendedAudience",
             "propertyLabel": "Intended Audience (RDA 7.7)",
@@ -29569,7 +25671,9 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": [],
+              "editable": "false"
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
             "propertyLabel": "Contribution (RDA 19.3 and 20.2)",
@@ -29587,7 +25691,8 @@
                 "profile:bf2:TopicInput"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subject",
             "propertyLabel": "Subject of the Work (RDA Chapter 23)",
@@ -29603,7 +25708,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work"
@@ -29615,10 +25721,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Contents"
+                "profile:bf2:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/tableOfContents",
             "propertyLabel": "Contents (LC-PCC PS 25.1)"
@@ -29630,10 +25737,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Summary"
+                "profile:bf2:Summary"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
             "propertyLabel": "Summary"
@@ -29651,10 +25759,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
-              "defaultLiteral": "performed music",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
+                  "defaultLiteral": "performed music"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
             "propertyLabel": "Content Type (RDA 6.9)",
@@ -29674,7 +25786,8 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
               },
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
             "propertyLabel": "Language",
@@ -29687,10 +25800,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Capture"
+                "profile:bf2:Capture"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture",
             "propertyLabel": "Capture information"
@@ -29702,10 +25816,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:SupplContent"
+                "profile:bf2:SupplContent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
             "propertyLabel": "Supplementary Content"
@@ -29718,7 +25833,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
             "propertyLabel": "Duration (RDA 7.22)",
@@ -29734,11 +25850,12 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works (RDA Chapter 25, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html"
+            "propertyLabel": "Related Works",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -29750,11 +25867,12 @@
                 "profile:bf2:RelatedExpression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasExpression",
-            "propertyLabel": "Related Expressions (RDA Chapter 26, Appendix J)",
-            "remark": "http://access.rdatoolkit.org/rdachp26_rda26-25.html"
+            "propertyLabel": "Related Expressions",
+            "remark": ""
           },
           {
             "mandatory": "false",
@@ -29766,7 +25884,8 @@
                 "profile:bf2:SoundRecording:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -29779,7 +25898,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
@@ -29805,7 +25925,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -29824,7 +25945,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -29839,7 +25961,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Statement of Responsibility Relating to Title Proper (RDA 2.4.2)",
             "remark": "http://access.rdatoolkit.org/2.4.2.html",
@@ -29852,7 +25975,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -29871,7 +25995,8 @@
                 "profile:bf2:DistributionInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -29887,7 +26012,8 @@
               "useValuesFrom": [
                 ""
               ],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/copyrightDate",
             "propertyLabel": "Copyright Date (RDA 2.11)",
@@ -29903,7 +26029,8 @@
                 "profile:bf2:SeriesInformation"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Series Statement",
             "remark": "",
@@ -29923,9 +26050,13 @@
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
               },
               "editable": "false",
-              "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
-              "defaultLiteral": "single unit",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/issuance/mono",
+                  "defaultLiteral": "single unit"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/issuance",
             "propertyLabel": "Mode of Issuance (RDA 2.13)",
@@ -29943,12 +26074,14 @@
                 "profile:bf2:Identifiers:PubNumber",
                 "profile:bf2:Identifiers:EAN",
                 "profile:bf2:Identifiers:UPC",
-                "profile:bf2:TestProfile:ISRC",
+                "profile:bf2:Identifiers:ISRC",
                 "profile:bf2:Identifiers:Other",
-                "profile:bf2:Identifiers:Local"
+                "profile:bf2:Identifiers:Local",
+                "profile:bf2:Identifiers:AudioIssue"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -29964,7 +26097,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Notes about the Instance",
             "remark": "http://access.rdatoolkit.org/2.17.html",
@@ -29980,7 +26114,8 @@
                 "profile:bf2:SoundRecording:Credits"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Credits",
             "remark": "http://access.rdatoolkit.org/2.17.3.5.html",
@@ -30000,10 +26135,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
-              "defaultLiteral": "audio",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/mediaTypes/s",
+                  "defaultLiteral": "audio"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.2.html"
@@ -30022,10 +26161,14 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
-              "defaultLiteral": "audio disc",
               "editable": "false",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/carriers/sd",
+                  "defaultLiteral": "audio disc"
+                }
+              ]
             },
             "mandatory": "false",
             "remark": "http://access.rdatoolkit.org/3.3.html"
@@ -30036,10 +26179,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Extent"
+                "profile:bf2:Extent"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -30061,7 +26205,8 @@
               "defaultLiteral": "",
               "editable": "true",
               "repeatable": "false",
-              "defaultURI": ""
+              "defaultURI": "",
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "false",
@@ -30083,7 +26228,8 @@
               },
               "editable": "true",
               "defaultLiteral": "",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyLabel": "Base Material (RDA 3.6)",
             "remark": "http://access.rdatoolkit.org/3.6.html",
@@ -30101,7 +26247,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/AppliedMaterial"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Applied Material (RDA 3.7)",
             "remark": "http://access.rdatoolkit.org/3.7.html",
@@ -30114,14 +26261,15 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Sound1",
-                "profile:bf2:SoundRecording:Sound2",
-                "profile:bf2:SoundRecording:Sound3",
-                "profile:bf2:SoundRecording:Sound4",
-                "profile:bf2:SoundRecording:Sound5"
+                "profile:bf2:TypeRec",
+                "profile:bf2:RecMedium",
+                "profile:bf2:PlayingSpeed",
+                "profile:bf2:Playback",
+                "profile:bf2:SpecPlayback"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/soundCharacteristic",
             "propertyLabel": "Sound Characteristics"
@@ -30133,9 +26281,9 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Digital",
-                "profile:bf2:SoundRecording:Digital1",
-                "profile:bf2:SoundRecording:Digital2"
+                "profile:bf2:FileType",
+                "profile:bf2:EncFmt",
+                "profile:bf2:FileSize"
               ],
               "useValuesFrom": [],
               "valueDataType": {
@@ -30143,7 +26291,8 @@
                 "dataTypeURI": ""
               },
               "editable": "true",
-              "defaultLiteral": ""
+              "defaultLiteral": "",
+              "defaults": []
             },
             "propertyLabel": "Digital Characteristics",
             "remark": "",
@@ -30156,10 +26305,11 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:SysReq"
+                "profile:bf2:SysReq"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/systemRequirement",
             "propertyLabel": "System Requirement"
@@ -30172,7 +26322,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -30188,7 +26339,8 @@
                 "profile:bf2:Identifiers:LCCN"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "LC Control Number for the Manifestation (RDA 2.15)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/identifiedBy",
@@ -30204,7 +26356,8 @@
                 "profile:bf2:AdminMetadata"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Administrative Metadata for Instance",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/adminMetadata"
@@ -30219,7 +26372,8 @@
                 "profile:bf2:SoundRecording:Item"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasItem",
             "propertyLabel": "Has Item"
@@ -30242,8 +26396,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
-              "defaultLiteral": "DLC"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/organizations/dlc",
+                  "defaultLiteral": "DLC"
+                }
+              ]
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -30257,7 +26415,8 @@
                 "profile:bf2:Identifiers:Shelfmark"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -30272,7 +26431,8 @@
                 "profile:bf2:Identifiers:Barcode"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -30285,7 +26445,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -30298,7 +26459,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -30313,7 +26475,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -30330,7 +26493,8 @@
                 "profile:bf2:Item:Retention"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -30350,49 +26514,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Contents note",
-            "remark": "http://access.rdatoolkit.org/lcpschp25_lcps25-354.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Contents",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/TableOfContents",
-        "resourceLabel": "Contents note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Summary note",
-            "remark": "http://access.rdatoolkit.org/7.10.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Summary",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Summary",
-        "resourceLabel": "Summary note"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Credits note"
@@ -30401,644 +26524,6 @@
         "id": "profile:bf2:SoundRecording:Credits",
         "resourceLabel": "Credits note",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Credits"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrumentalType",
-            "propertyLabel": "Type of instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:MedPerfInst",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicInstrument",
-        "resourceLabel": "Instrument"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/voiceType",
-            "propertyLabel": "Type of voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:MedPerfVoice",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicVoice",
-        "resourceLabel": "Voice"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/authorities/performanceMediums"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/MusicMedium"
-              },
-              "repeatable": "false"
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "LCMPT for Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/count",
-            "propertyLabel": "Number"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensembleType",
-            "propertyLabel": "Type of Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:MedPerfEnsemble",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicEnsemble",
-        "resourceLabel": "Ensemble"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Place"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/place",
-            "propertyLabel": "Place of Capture (RDA 7.11.2)",
-            "remark": "http://access.rdatoolkit.org/7.11.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/date",
-            "propertyLabel": "Date of Capture (RDA 7.11.3)",
-            "remark": "http://access.rdatoolkit.org/7.11.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Capture note"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Capture",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Capture",
-        "resourceLabel": "Capture information"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
-              }
-            },
-            "propertyLabel": "Place",
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Place",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Place",
-        "resourceLabel": "Place"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrectype"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/RecordingMethod"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Type of Recording (RDA 3.16.2)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Type of Recording (RDA 3.16.2.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.2.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Sound1",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMethod",
-        "resourceLabel": "Type of Recording"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mrecmedium"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/RecordingMedium"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Recording Medium (RDA 3.16.3)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Recording Medium (RDA 3.16.3.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.3.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Sound2",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/RecordingMedium",
-        "resourceLabel": "Recording Medium"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Playing Speed (RDA 3.16.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Sound3",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlayingSpeed",
-        "resourceLabel": "Playing Speed"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Configuration of Playback Channels (RDA 3.16.8)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Details of Configuration of Playback Channels (RDA 3.16.8.4)",
-            "remark": "http://access.rdatoolkit.org/3.16.8.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Sound4",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackChannels",
-        "resourceLabel": "Playback Channels"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mspecplayback"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "Special Playback Characteristic (RDA 3.16.9)",
-            "remark": "http://access.rdatoolkit.org/3.16.9.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Sound5",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/PlaybackCharacteristic",
-        "resourceLabel": "Special Playback Characteristic"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "target",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/mfiletype"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/FileType"
-              },
-              "editable": "false",
-              "repeatable": "true"
-            },
-            "propertyLabel": "File Type (RDA 3.19)",
-            "remark": "http://access.rdatoolkit.org/3.19.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Digital",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileType",
-        "resourceLabel": "File type"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Encoding Format (RDA 3.19.3)",
-            "remark": "http://access.rdatoolkit.org/3.19.3.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Digital1",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/EncodingFormat",
-        "resourceLabel": "Encoding format"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "File Size (RDA 3.19.4)",
-            "remark": "http://access.rdatoolkit.org/3.19.4.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Digital2",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/FileSize",
-        "resourceLabel": "File size"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Extent (RDA 3.4)",
-            "remark": "http://access.rdatoolkit.org/3.4.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on extent"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:Extent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Extent",
-        "resourceLabel": "Extent"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "remark": "http://access.rdatoolkit.org/3.20.html",
-            "propertyLabel": "System Requirement (RDA 3.20)"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:SysReq",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SystemRequirement",
-        "resourceLabel": "System Requirement"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
-              }
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Supplementary Content (RDA 7.16)",
-            "remark": "http://access.rdatoolkit.org/7.16.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
-            "propertyLabel": "URI for Supplementary Content"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:SupplContent",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent",
-        "resourceLabel": "Supplementary Content"
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Medium of Performance (RDA 7.21)",
-            "remark": "http://access.rdatoolkit.org/7.21.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:MOPStatement",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/MusicMedium",
-        "resourceLabel": "Medium of Performance Statement"
       },
       {
         "id": "profile:bf2:SoundRecording:WorkOld",
@@ -31056,7 +26541,8 @@
               "valueTemplateRefs": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
+              },
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true"
@@ -31073,7 +26559,8 @@
               "useValuesFrom": [],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
-              }
+              },
+              "defaults": []
             },
             "propertyLabel": "Creator of Work (RDA 19.2)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution",
@@ -31091,7 +26578,8 @@
                 "profile:bflc:TranscribedTitle"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -31107,7 +26595,8 @@
                 "profile:bf2:Form"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -31125,7 +26614,8 @@
                 "dataTypeLabel": "EDTF",
                 "dataTypeLabelHint": "ISO",
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.4.html",
             "mandatory": "false",
@@ -31142,7 +26632,8 @@
                 "profile:bf2:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/6.5.html",
             "mandatory": "false",
@@ -31160,7 +26651,8 @@
               ],
               "useValuesFrom": [],
               "valueDataType": {},
-              "editable": "false"
+              "editable": "false",
+              "defaults": []
             },
             "propertyLabel": "Medium of Performance (RDA 6.15)",
             "remark": "http://access.rdatoolkit.org/6.15.html",
@@ -31176,7 +26668,8 @@
                 "profile:bf2:SoundRecording:MedPerfInst"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
             "propertyLabel": "Medium of Performance - Instrument"
@@ -31191,7 +26684,8 @@
                 "profile:bf2:SoundRecording:MedPerfVoice"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
             "propertyLabel": "Medium of Performance - Voice"
@@ -31206,7 +26700,8 @@
                 "profile:bf2:SoundRecording:MedPerfEnsemble"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
             "propertyLabel": "Medium of Performance - Ensemble"
@@ -31219,7 +26714,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Numerical Designation of a Musical Work (RDA 6.16)",
             "remark": "http://access.rdatoolkit.org/6.16.html",
@@ -31233,7 +26729,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Key (RDA 6.17)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/musicKey",
@@ -31248,7 +26745,8 @@
                 "profile:bf2:Form:Geog"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -31263,7 +26761,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/temporalCoverage",
             "propertyLabel": "(Temporal) Coverage of the Content (RDA 7.3)",
@@ -31281,7 +26780,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
-              }
+              },
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/7.7.html",
             "mandatory": "false",
@@ -31297,7 +26797,8 @@
                 "profile:bf2:Agents:Contribution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Other Person, Family, or Corporate Body Associated With a Work (RDA 19.3)",
             "remark": "http://access.rdatoolkit.org/19.3.html",
@@ -31313,7 +26814,8 @@
                 "profile:bf2:Topic"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp23_rda23-12.html",
             "mandatory": "false",
@@ -31326,7 +26828,8 @@
                 "profile:bf2:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Notes about the Work",
@@ -31346,7 +26849,8 @@
                 "profile:bf2:DDC"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/classification",
             "propertyLabel": "Classification numbers"
@@ -31361,7 +26865,8 @@
                 "profile:bf2:RelatedWork"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "http://access.rdatoolkit.org/rdachp25_rda25-65.html",
             "mandatory": "false",
@@ -31376,7 +26881,8 @@
                 "profile:bf2:SoundRecording:Contents"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "mandatory": "false",
             "repeatable": "true",
@@ -31393,7 +26899,8 @@
                 "profile:bf2:SoundRecording:Expression"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "remark": "",
             "mandatory": "false",
@@ -31407,7 +26914,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Authorized Access Point for the Musical Work (RDA 6.28.1)",
@@ -31421,7 +26929,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/comment",
             "propertyLabel": "Your Windows ID and Comments"
@@ -31436,7 +26945,8 @@
                 "profile:bf2:SoundRecording:Instance"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/hasInstance",
             "propertyLabel": "Has BIBFRAME Instance"
@@ -31451,269 +26961,13 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://mlvlp04.loc.gov:8230/resources/works"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Work"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/expressionOf",
-            "propertyLabel": "Expression of",
-            "remark": "Expression has a related work. For use to connect Works under FRBR/RDA rules."
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:MedPerfInst"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/instrument",
-            "propertyLabel": "Medium of Performance - Instrument"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:MedPerfVoice"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/voice",
-            "propertyLabel": "Medium of Performance - Voice"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:MedPerfEnsemble"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ensemble",
-            "propertyLabel": "Medium of Performance - Ensemble"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "false",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/contentTypes"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content",
-                "dataTypeLabel": ""
-              },
-              "editable": "true",
-              "defaultURI": "http://id.loc.gov/vocabulary/contentTypes/prm",
-              "defaultLiteral": "performed music",
-              "remark": ""
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/content",
-            "propertyLabel": "Content Type (RDA 6.9)",
-            "remark": "http://access.rdatoolkit.org/6.9.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "literal",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Date of Expression (RDA 6.10)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/originDate",
-            "remark": "http://access.rdatoolkit.org/6.10.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                "http://id.loc.gov/vocabulary/languages"
-              ],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Language"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
-            "propertyLabel": "Language of Expression (RDA 6.11)",
-            "remark": "http://access.rdatoolkit.org/6.11.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Summary"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/summary",
-            "propertyLabel": "Summary",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:Capture"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Capture information",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/capture"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Language:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "http://id.loc.gov/vocabulary/languages"
-              }
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/language",
-            "propertyLabel": "Language of Content (RDA 7.12)",
-            "remark": "http://access.rdatoolkit.org/7.12.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:SoundRecording:SupplContent"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/supplementaryContent",
-            "propertyLabel": "Supplementary Content",
-            "remark": ""
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [
-                ""
-              ],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/duration",
-            "propertyLabel": "Duration (RDA 7.22)",
-            "remark": "http://access.rdatoolkit.org/7.22.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Agents:Contribution"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Contributor (RDA 20.2)",
-            "remark": "http://access.rdatoolkit.org/20.2.html",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/contribution"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Notes about the Expression",
-            "remark": "",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "propertyLabel": "Authorized Access Point for the Musical Expression (RDA 6.28.3)",
-            "remark": "http://access.rdatoolkit.org/6.28.3.html"
-          }
-        ],
-        "id": "profile:bf2:SoundRecording:ExpressionOld",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Work",
-        "resourceLabel": "BIBFRAME Work (RDA Expression Elements)"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
             "propertyLabel": "Title Proper (RDA 2.3.2) (BIBFRAME: Main title)",
@@ -31727,7 +26981,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
             "propertyLabel": "Other Title Information (RDA 2.3.4) (BIBFRAME: Subtitle)",
@@ -31741,10 +26996,11 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyLabel": "Part name",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName"
+            "propertyLabel": "Part number",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber"
           },
           {
             "mandatory": "false",
@@ -31754,10 +27010,11 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
-            "propertyLabel": "Part number",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber"
+            "propertyLabel": "Part name",
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName"
           },
           {
             "mandatory": "false",
@@ -31769,7 +27026,8 @@
                 "profile:bf2:Title:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on title",
@@ -31791,7 +27049,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
             "propertyLabel": "Title"
@@ -31806,7 +27065,8 @@
                 "profile:bf2:Title:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on title",
@@ -31827,7 +27087,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
             "propertyLabel": "Preferred Title for Work (RDA 6.2.2, RDA 6.14.2) (BIBFRAME: Main title)",
@@ -31841,7 +27102,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/partName",
             "propertyLabel": "Part name"
@@ -31854,7 +27116,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/partNumber",
             "propertyLabel": "Part number"
@@ -31869,7 +27132,8 @@
                 "profile:bf2:Title:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on title"
@@ -31889,7 +27153,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Variant Title for Work (RDA 6.2.3, 6.14.3 (Music))",
             "remark": "http://access.rdatoolkit.org/rdachp6_rda6-2658.html",
@@ -31905,7 +27170,8 @@
                 "profile:bf2:Title:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on title"
@@ -31925,7 +27191,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
             "propertyLabel": "Note Text"
@@ -31945,7 +27212,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
             "propertyLabel": "Variant Title (RDA 2.3.6)",
@@ -31959,7 +27227,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/variantType",
             "propertyLabel": "Variant title type"
@@ -31979,7 +27248,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "Parallel Title Proper (RDA 2.3.3)",
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
@@ -31993,7 +27263,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
             "propertyLabel": "Parallel Other Title Information (RDA 2.3.5)",
@@ -32009,7 +27280,8 @@
                 "profile:bf2:Title:Note"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
             "propertyLabel": "Note on Parallel Title",
@@ -32030,7 +27302,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
             "propertyLabel": "Key Title"
@@ -32050,7 +27323,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
             "propertyLabel": "Abbreviated Title"
@@ -32070,7 +27344,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mainTitle",
             "propertyLabel": "Collective Title"
@@ -32090,113 +27365,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyLabel": "Parallel Title Proper (RDA 2.3.3)",
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/ParallelTitle",
-            "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3695.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/subtitle",
-            "propertyLabel": "Parallel Other Title Information (RDA 2.3.5)",
-            "remark": "http://access.rdatoolkit.org/rdachp2_rda2-3939.html"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/KeyTitle",
-            "propertyLabel": "Key title"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/AbbreviatedTitle",
-            "propertyLabel": "Abbreviated title"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/CollectiveTitle",
-            "propertyLabel": "Collective title"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://www.w3.org/2000/01/rdf-schema#label",
-            "remark": "http://access.rdatoolkit.org/rdachp2_rda2-4013.html",
-            "propertyLabel": "Variant Title (RDA 2.3.6)"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "resource",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [
-                "profile:bf2:Title:Note"
-              ],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://id.loc.gov/ontologies/bibframe/note",
-            "propertyLabel": "Note on title",
-            "remark": "http://access.rdatoolkit.org/2.17.2.html"
-          }
-        ],
-        "contact": "Title variation",
-        "resourceLabel": "Instance Title Variation",
-        "resourceURI": "http://id.loc.gov/ontologies/bibframe/VariantTitle",
-        "id": "profile:bf2:VariantTitle",
-        "remark": "Title associated with the resource that is different from the Work or Instance title."
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title00MarcKey",
             "propertyLabel": "LC Extension: title00MarcKey"
@@ -32209,7 +27379,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title00MatchKey",
             "propertyLabel": "LC Extension: title00MatchKey"
@@ -32222,7 +27393,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title10MarcKey",
             "propertyLabel": "LC Extension: title10MarcKey"
@@ -32235,7 +27407,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title10MatchKey",
             "propertyLabel": "LC Extension: title10MatchKey"
@@ -32248,7 +27421,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title11MarcKey",
             "propertyLabel": "LC Extension: title11MarcKey"
@@ -32261,7 +27435,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title11MatchKey",
             "propertyLabel": "LC Extension: title11MatchKey"
@@ -32274,7 +27449,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title30MarcKey",
             "propertyLabel": "LC Extension: title30MarcKey"
@@ -32287,7 +27463,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title30MatchKey",
             "propertyLabel": "LC Extension: title30MatchKey"
@@ -32300,7 +27477,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title40MarcKey",
             "propertyLabel": "LC Extension: title40MarcKey"
@@ -32313,7 +27491,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/title40MatchKey",
             "propertyLabel": "LC Extension: title40MatchKey"
@@ -32326,7 +27505,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/titleSortKey",
             "propertyLabel": "LC Extension: titleSortKey"
@@ -32335,12 +27515,7 @@
         "id": "profile:bf2:BflcTitle",
         "resourceURI": "http://id.loc.gov/ontologies/bflc",
         "resourceLabel": "Title: BIBFRAME 2.0 LC Extension"
-      }
-    ],
-    "remark": ""
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -32358,7 +27533,8 @@
                 "dataTypeURI": ""
               },
               "repeatable": "false",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
             "propertyLabel": "Search LCSH/LCNAF"
@@ -32383,8 +27559,11 @@
                 "profile:bf2:Topic:madsGenreForm"
               ],
               "useValuesFrom": [],
-              "valueDataType": {},
-              "repeatable": "false"
+              "valueDataType": {
+                "dataTypeURI": "http://www.loc.gov/mads/rdf/v1#ComplexSubject"
+              },
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#componentList",
             "propertyLabel": "Search Subject Components"
@@ -32406,7 +27585,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "editable": "true",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
             "propertyLabel": "Input Subject + Subdivision string"
@@ -32424,8 +27604,12 @@
               "valueDataType": {
                 "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Source"
               },
-              "defaultURI": "http://id.loc.gov/vocabulary/subjectSchemes/lcsh",
-              "defaultLiteral": "LCSH"
+              "defaults": [
+                {
+                  "defaultURI": "http://id.loc.gov/vocabulary/subjectSchemes/lcsh",
+                  "defaultLiteral": "LCSH"
+                }
+              ]
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Subject source"
@@ -32452,7 +27636,8 @@
                 "dataTypeURI": ""
               },
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyLabel": "Search LCSH/LCNAF",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
@@ -32478,7 +27663,8 @@
                 "dataTypeURI": ""
               },
               "editable": "true",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyLabel": "Search LCSH",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
@@ -32504,7 +27690,8 @@
                 "dataTypeURI": ""
               },
               "repeatable": "true",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyLabel": "Search LCSH",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
@@ -32531,7 +27718,8 @@
                 "dataTypeURI": ""
               },
               "editable": "true",
-              "repeatable": "true"
+              "repeatable": "true",
+              "defaults": []
             },
             "propertyLabel": "Search LCNAF/LCSH",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel"
@@ -32546,7 +27734,8 @@
               "useValuesFrom": [],
               "valueDataType": {},
               "editable": "true",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
             "propertyLabel": "Input Geographic Term"
@@ -32573,7 +27762,8 @@
                 "dataTypeURI": ""
               },
               "editable": "true",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyLabel": "Search LCSH/LCNAF",
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#Topic"
@@ -32596,7 +27786,8 @@
                 "dataTypeURI": ""
               },
               "editable": "true",
-              "repeatable": "false"
+              "repeatable": "false",
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#componentList",
             "propertyLabel": "Search Subject Components"
@@ -32613,7 +27804,8 @@
                 "dataTypeURI": ""
               },
               "repeatable": "false",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://www.loc.gov/mads/rdf/v1#authoritativeLabel",
             "propertyLabel": "Input Subject + Subdivision string"
@@ -32633,7 +27825,8 @@
               },
               "defaultURI": "",
               "repeatable": "false",
-              "editable": "true"
+              "editable": "true",
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/source",
             "propertyLabel": "Subject source"
@@ -32642,11 +27835,7 @@
         "id": "profile:bf2:Topic",
         "resourceURI": "http://id.loc.gov/ontologies/bibframe/Topic",
         "resourceLabel": "Subject of Work"
-      }
-    ]
-  },
-  {
-    "resourceTemplates": [
+      },
       {
         "propertyTemplates": [
           {
@@ -32659,7 +27848,8 @@
                 "profile:bf2:PMOMedPerf:MedPart2"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
             "propertyLabel": "has Medium Part"
@@ -32672,7 +27862,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
             "propertyLabel": "Total Distinct Part Count"
@@ -32685,7 +27876,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
             "propertyLabel": "Total Required Performer Count"
@@ -32698,7 +27890,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
             "propertyLabel": "Total Ensemble Count"
@@ -32720,7 +27913,8 @@
                 "profile:bf2:PMOMedPerf:MedPart"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
             "propertyLabel": "has Medium Part"
@@ -32733,7 +27927,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
             "propertyLabel": "has Distinct Part Count"
@@ -32746,7 +27941,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
             "propertyLabel": "has Ensemble Count"
@@ -32759,7 +27955,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasPerformerCount",
             "propertyLabel": "Performer Count"
@@ -32782,7 +27979,8 @@
                 "profile:bf2:PMOMedPerf:MedPerfI2"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMediumOfPerformance",
             "propertyLabel": "has Medium of Performance"
@@ -32805,7 +28003,8 @@
                 "profile:bf2:PMOMedPerf:MedPerfI2"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMediumOfPerformance",
             "propertyLabel": "has Medium of Performance"
@@ -32818,7 +28017,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
             "propertyLabel": "has Distinct Part Count"
@@ -32831,7 +28031,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
             "propertyLabel": "has Required Performer Count"
@@ -32844,7 +28045,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
             "propertyLabel": "has Ensemble Count"
@@ -32857,7 +28059,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasPerformerCount",
             "propertyLabel": "has Performer Count"
@@ -32882,7 +28085,8 @@
               "valueDataType": {
                 "dataTypeURI": "http://performedmusicontology.org/ontology/IndividualInstrument",
                 "remark": ""
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Individual Instrument or Voice"
@@ -32895,7 +28099,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
             "propertyLabel": "Distinct Part Count"
@@ -32908,7 +28113,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
             "propertyLabel": "Required Performer Count"
@@ -32932,7 +28138,8 @@
               ],
               "valueDataType": {
                 "dataTypeURI": "http://performedmusicontology.org/ontology/InstrumentEnsemble"
-              }
+              },
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/target",
             "propertyLabel": "Ensemble"
@@ -32945,7 +28152,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
             "propertyLabel": "has Ensemble Count"
@@ -32960,53 +28168,6 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
-            "propertyLabel": "has Distinct Part Count"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
-            "propertyLabel": "has Required Part Count"
-          },
-          {
-            "mandatory": "false",
-            "repeatable": "true",
-            "type": "literal",
-            "resourceTemplates": [],
-            "valueConstraint": {
-              "valueTemplateRefs": [],
-              "useValuesFrom": [],
-              "valueDataType": {}
-            },
-            "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
-            "propertyLabel": "has Ensemble Count"
-          }
-        ],
-        "id": "profile:bf2:PMOMedPerf:DecMedTotals",
-        "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
-        "resourceLabel": "Medium of Performance: Totaling Counts for the Entire Work",
-        "remark": ""
-      },
-      {
-        "propertyTemplates": [
-          {
-            "mandatory": "false",
-            "repeatable": "true",
             "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
@@ -33014,7 +28175,8 @@
                 "profile:bf2:PMOMedPerf:MedPart2"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
             "propertyLabel": "has Medium Part"
@@ -33029,7 +28191,8 @@
                 "profile:bf2:PMOMedPerf:MedPart2"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/alternateMediumOfPerformance",
             "propertyLabel": "OR has Alternate Medium Part"
@@ -33041,13 +28204,14 @@
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
-                "profile:bf2:PMOMedPerf:MedPart2"
+                "profile:bf2:PMOMedPerf:Doubling"
               ],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyLabel": "OR has Doubling Medium Part",
-            "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance"
+            "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart"
           },
           {
             "mandatory": "false",
@@ -33057,7 +28221,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasDistinctPartCount",
             "propertyLabel": "Total Distinct Part Count"
@@ -33070,10 +28235,11 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasRequiredPerformerCount",
-            "propertyLabel": "Total Required Part Count"
+            "propertyLabel": "Total Required Performer Count"
           },
           {
             "mandatory": "false",
@@ -33083,7 +28249,8 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {}
+              "valueDataType": {},
+              "defaults": []
             },
             "propertyURI": "http://performedmusicontology.org/ontology/hasEnsembleCount",
             "propertyLabel": "Total Ensemble Count"
@@ -33092,6 +28259,126 @@
         "id": "profile:bf2:PMOMedPerf:DecMedTest",
         "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
         "resourceLabel": "Declared Medium Test"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Agent:Person"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/agent",
+            "propertyLabel": "Agent"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:Agent:Role"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://id.loc.gov/ontologies/bibframe/role",
+            "propertyLabel": "Role"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [],
+              "useValuesFrom": [
+                "http://id.loc.gov/authorities/performanceMediums"
+              ],
+              "defaults": [],
+              "valueDataType": {
+                "dataTypeURI": "http://performedmusicontology.org/ontology/IndividualMediumOfPerformance"
+              }
+            },
+            "propertyURI": "http://performedmusicontology.org/ontology/hasMediumOfPerformance",
+            "propertyLabel": "Medium of Performance"
+          }
+        ],
+        "id": "profile:bf2:PMOAgentPerf",
+        "resourceURI": "http://id.loc.gov/ontologies/bibframe/Contribution",
+        "resourceLabel": "Agent, Role, Medium of Performance"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:PMOMedPerf:MedPart2"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
+            "propertyLabel": "Declared Medium of Performance"
+          },
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:PMOMedPerf:Doubling"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://performedmusicontology.org/ontology/hasMediumPart",
+            "propertyLabel": "Doubling Medium of Performance"
+          }
+        ],
+        "id": "profile:bf2:PMODecDoubling",
+        "resourceURI": "http://performedmusicontology.org/ontology/DeclaredMedium",
+        "resourceLabel": "Declared + Doubling"
+      },
+      {
+        "propertyTemplates": [
+          {
+            "mandatory": "false",
+            "repeatable": "true",
+            "type": "resource",
+            "resourceTemplates": [],
+            "valueConstraint": {
+              "valueTemplateRefs": [
+                "profile:bf2:PMOMedPerf:MedPerfI1",
+                "profile:bf2:PMOMedPerf:MedPerfI2"
+              ],
+              "useValuesFrom": [],
+              "defaults": [],
+              "valueDataType": {}
+            },
+            "propertyURI": "http://performedmusicontology.org/ontology/hasDoublingMediumOfPerformance",
+            "propertyLabel": "Doubling Medium of Performance"
+          }
+        ],
+        "id": "profile:bf2:PMOMedPerf:Doubling",
+        "resourceURI": "http://performedmusicontology.org/ontology/MediumPart",
+        "resourceLabel": "Doubling Medium of Performance"
       }
     ]
   }


### PR DESCRIPTION
Updates the giant list of resource templates only, as of lcnetdev/verso  ecb3c1e, with corrections to incorrect json (extra commas) in Agent profile.

Does not update the list of all profiles, nor the individual verso profiles.

Connects to #4