### PR TITLE
JSON schemas that work for (slightly edited) LC profiles thru ecb3c1e

### DIFF
--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Agents.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Agents.json
@@ -14,9 +14,6 @@
                 "http://id.loc.gov/authorities/names"
               ],
               "valueTemplateRefs": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "valueLanguage": "",
               "defaults": [],
               "editable": "true"
@@ -194,9 +191,6 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "true",
               "defaults": [],
               "editable": "true"
@@ -438,9 +432,6 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "true",
               "defaults": [],
               "editable": "true"
@@ -698,9 +689,6 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "true",
               "defaults": [],
               "editable": "true"
@@ -961,9 +949,6 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "true",
               "defaults": [],
               "editable": "true"
@@ -1524,9 +1509,6 @@
               "useValuesFrom": [
                 "http://id.loc.gov/vocabulary/relators"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "false",
               "defaults": []
             },
@@ -1541,9 +1523,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "false",
               "defaults": []
             },

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Cartographic.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Cartographic.json
@@ -375,7 +375,7 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "Related Works (RDA Chapter 25 and Appendix J)",
+            "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [
@@ -386,7 +386,7 @@
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bflc/relationship",
-            "propertyLabel": "Related Works",
+            "propertyLabel": "Related Works (RDA Chapter 25 and Appendix J)",
             "remark": ""
           },
           {

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Edition Information.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Edition Information.json
@@ -55,7 +55,7 @@
     "id": "profile:bf2:EditionInformation",
     "title": "BIBFRAME 2.0 Edition Information",
     "description": "Edition (unused)",
-    "contact": "NDMSO",
+    "author": "NDMSO",
     "date": "2017-06-08"
   }
 }

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Form.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Form.json
@@ -13,9 +13,6 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/genreForms"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "false",
               "defaults": []
             },
@@ -41,10 +38,6 @@
                 "http://id.loc.gov/authorities/names",
                 "http://id.loc.gov/authorities/subjects"
               ],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": ""
-              },
               "repeatable": "false",
               "remark": "",
               "defaults": []

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Moving Image-BluRay DVD.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Moving Image-BluRay DVD.json
@@ -1058,12 +1058,6 @@
                 "profile:bf2:Resolution"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeLabel": "",
-                "dataTypeURI": "",
-                "dataTypeLabelHint": "",
-                "remark": ""
-              },
               "defaults": []
             },
             "propertyLabel": "Digital File Characteristics",

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Moving Image-BluRay DVD.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Moving Image-BluRay DVD.json
@@ -190,7 +190,7 @@
           {
             "mandatory": "false",
             "repeatable": "true",
-            "type": "Creator of Work (RDA 19.2)",
+            "type": "resource",
             "resourceTemplates": [],
             "valueConstraint": {
               "valueTemplateRefs": [

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Place.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Place.json
@@ -14,10 +14,6 @@
                 "http://id.loc.gov/authorities/names",
                 "http://id.loc.gov/authorities/subjects"
               ],
-              "valueDataType": {
-                "remark": "",
-                "dataTypeURI": ""
-              },
               "repeatable": "false",
               "defaults": []
             },
@@ -32,10 +28,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": "",
-                "remark": "http://id.loc.gov/ontologies/bibframe/Place"
-              },
               "repeatable": "false",
               "defaults": []
             },

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Publication, Distribution, Manufacturer Activity.json
@@ -183,9 +183,6 @@
                 "profile:bf2:Provision:Place"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "true",
               "editable": "true",
               "defaults": []
@@ -204,9 +201,6 @@
                 "profile:bf2:Provision:Name"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "true",
               "editable": "true",
               "defaults": []

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 RWO.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 RWO.json
@@ -29,7 +29,6 @@
               "valueTemplateRefs": [],
               "useValuesFrom": [],
               "valueDataType": {
-                "dataTypeURI": "",
                 "dataTypeLabel": "SKOS"
               },
               "defaultURI": ""

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Serial.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Serial.json
@@ -624,9 +624,6 @@
                 "profile:bf2:Serial:Frequency"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyLabel": "Frequency",
@@ -1119,9 +1116,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/absorbed",
@@ -1136,9 +1130,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyLabel": "Continues (work):",
@@ -1153,9 +1144,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/continuesInPart",
@@ -1170,9 +1158,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mergerOf",
@@ -1187,9 +1172,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/separatedFrom",
@@ -1204,9 +1186,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyLabel": "Continued by (work):",
@@ -1221,9 +1200,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/absorbedBy",
@@ -1238,9 +1214,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/continuedInPartBy",
@@ -1255,9 +1228,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/mergedToForm",
@@ -1272,9 +1242,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "propertyURI": "http://id.loc.gov/ontologies/bibframe/splitInto",

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Sound Recording-Analog.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Sound Recording-Analog.json
@@ -581,9 +581,6 @@
                 "profile:bf2:Analog:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "mandatory": "false",

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Sound Recording-Audio CD-R.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Sound Recording-Audio CD-R.json
@@ -567,9 +567,6 @@
                 "profile:bf2:SoundCDR:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "mandatory": "false",

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Sound Recording-Audio CD.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Sound Recording-Audio CD.json
@@ -565,9 +565,6 @@
                 "profile:bf2:SoundRecording:Work"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "defaults": []
             },
             "mandatory": "false",
@@ -928,10 +925,6 @@
                 "profile:bf2:FileSize"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeLabelHint": "",
-                "dataTypeURI": ""
-              },
               "editable": "true",
               "defaultLiteral": "",
               "defaults": []

--- a/bfe-verso-profiles/profiles/BIBFRAME 2.0 Topic.json
+++ b/bfe-verso-profiles/profiles/BIBFRAME 2.0 Topic.json
@@ -14,9 +14,6 @@
                 "http://id.loc.gov/authorities/subjects",
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "false",
               "editable": "true",
               "defaults": []
@@ -117,9 +114,6 @@
                 "http://id.loc.gov/authorities/subjects",
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "true",
               "editable": "true",
               "defaults": []
@@ -144,9 +138,6 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/subjects"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "editable": "true",
               "repeatable": "true",
               "defaults": []
@@ -171,9 +162,6 @@
               "useValuesFrom": [
                 "http://id.loc.gov/authorities/subjects"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "true",
               "editable": "true",
               "defaults": []
@@ -199,9 +187,6 @@
                 "http://id.loc.gov/authorities/names",
                 "http://id.loc.gov/authorities/subjects"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "editable": "true",
               "repeatable": "true",
               "defaults": []
@@ -243,9 +228,6 @@
                 "http://id.loc.gov/authorities/subjects",
                 "http://id.loc.gov/authorities/names"
               ],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "editable": "true",
               "repeatable": "false",
               "defaults": []
@@ -266,10 +248,6 @@
                 "profile:bf2:Topic:madsGenreForm"
               ],
               "useValuesFrom": [],
-              "valueDataType": {
-                "remark": "",
-                "dataTypeURI": ""
-              },
               "editable": "true",
               "repeatable": "false",
               "defaults": []
@@ -285,9 +263,6 @@
             "valueConstraint": {
               "valueTemplateRefs": [],
               "useValuesFrom": [],
-              "valueDataType": {
-                "dataTypeURI": ""
-              },
               "repeatable": "false",
               "editable": "true",
               "defaults": []

--- a/bfe-verso-profiles/schemas/profile.json
+++ b/bfe-verso-profiles/schemas/profile.json
@@ -15,6 +15,7 @@
         "date",
         "description",
         "id",
+        "resourceTemplates",
         "title"
       ],
       "properties": {

--- a/bfe-verso-profiles/schemas/profile.json
+++ b/bfe-verso-profiles/schemas/profile.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "profile",
+  "type": "object",
+  "title": "LC Profile Schema (by Sinopia)",
+  "description": "Profile, or array of Resource Templates with some top-level metadata.",
+  "version": "0.0.1",
+  "required": [ "Profile" ],
+  "properties": {
+    "Profile": {
+      "type": "object",
+      "title": "Profile" ,
+      "description": "Profile key always at top level of a LC BFE / Sinopia BFF Profile.",
+      "required": [
+        "author",
+        "date",
+        "description",
+        "id",
+        "title"
+      ],
+      "properties": {
+        "author": {
+          "type": "string",
+          "title": "Author",
+          "description": "Contact information associated with the profile.",
+          "example": [
+            "PCC",
+            "Michelle Futornick",
+            "Cornell University Cataloging Department"
+          ]
+        },
+        "date": {
+          "type": "string",
+          "format": "date",
+          "title": "Date",
+          "description": "Date associated with the profile",
+          "example": [
+            "2017-05-20"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Textual description associated with the profile.",
+          "example": [
+            "Metadata for BIBFRAME Resources"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Identifier",
+          "description": "Unique identifier associated with the profile. Eventually, a Profile URI.",
+          "example": [
+            "profile:bf2:AdminMetadata",
+            "http://sinopia.io/resources/common/AdminMetadataProfile"
+          ]
+        },
+        "remark": {
+          "type": "string",
+          "title": "Remark",
+          "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+        },
+        "resourceTemplates": {
+          "$ref": "resource-templates-array"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "Textual title associated with the profile.",
+          "example": [
+            "BIBFRAME 2.0 Admin Metadata"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/bfe-verso-profiles/schemas/profile.json
+++ b/bfe-verso-profiles/schemas/profile.json
@@ -12,7 +12,6 @@
       "title": "Profile" ,
       "description": "Profile key always at top level of a LC BFE / Sinopia BFF Profile.",
       "required": [
-        "author",
         "date",
         "description",
         "id",

--- a/bfe-verso-profiles/schemas/profiles-array.json
+++ b/bfe-verso-profiles/schemas/profiles-array.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "profiles-array",
+  "title": "LC Profile Array Schema (i.e. Multiple Profiles) (by Sinopia)",
+  "version": "0.0.1",
+  "type": "array",
+  "items": {
+    "$ref": "profile"
+  }
+}

--- a/bfe-verso-profiles/schemas/property-template.json
+++ b/bfe-verso-profiles/schemas/property-template.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "property-template",
+  "title": "LC Property Template Schema (by Sinopia)",
+  "description": "Property template for property associated with the entity described by a resource template.",
+  "version": "0.0.1",
+  "type": "object",
+  "required": [
+    "propertyURI",
+    "propertyLabel",
+    "type"
+  ],
+  "properties": {
+    "mandatory": {
+      "type": "string",
+      "title": "Mandatory",
+      "description": "Indication that the property is mandatory."
+    },
+    "propertyLabel": {
+      "type": "string",
+      "title": "Resource Label",
+      "description": "Preferred, human readable label associated with the property.",
+      "example": [
+        "BIBFRAME 2.0 Admin Metadata"
+      ]
+    },
+    "propertyURI": {
+      "type": "string",
+      "format": "uri",
+      "title": "Resource URI",
+      "description": "URI of the RDF property being described.",
+      "example": [
+        "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+      ]
+    },
+    "remark": {
+      "type": "string",
+      "title": "Remark",
+      "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+    },
+    "repeatable": {
+      "type": "string",
+      "title": "Repeatable",
+      "description": "Indication that the property is repeatable."
+    },
+    "resourceTemplates": {
+      "type": "array",
+      "title": "Always empty array of Resource Template References",
+      "description": "This is not currently used",
+      "maxItems": 0
+    },
+    "type": {
+      "type": "string",
+      "enum": ["literal", "lookup", "resource", "target"],
+      "title": "Type",
+      "description": "Type of value (literal / resource / lookup / target) that is allowed by this property."
+    },
+    "valueConstraint": {
+      "type": "object",
+      "title": "Value Constraint",
+      "description": "Constraint associated with the value.",
+      "properties": {
+        "valueLanguage": {
+          "type": "string",
+          "title": "literal value language",
+          "description": "Language specified for a literal.  Never used/ignored?",
+          "maxLength": 0
+        },
+        "remark": {
+          "type": "string",
+          "title": "dataType remark",
+          "description": "Comment or guiding statement intended to be presented as supplementary information in user display.  Ignored."
+        },
+        "editable": {
+          "type": "string",
+          "title": "Editable",
+          "description": "Whether the value provided for the property is meant to be modified by a cataloger."
+        },
+        "repeatable": {
+          "type": "string",
+          "title": "Repeatable",
+          "description": "Indication whether the valueConstraint(?) is repeatable. (confusing)"
+        },
+        "validatePattern": {
+          "type": "string",
+          "title": "validation pattern",
+          "description": "Regular expression for input validation.  Never used/ignored.",
+          "maxLength": 0
+        },
+        "valueTemplateRefs": {
+          "type": "array",
+          "title": "Array of Resource Template References",
+          "description": "Array of identifiers (eventually URIs) for Resource Templates.",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "['profile:bf2:Agent:Person', 'profile:bf2:Identifiers:Barcode', 'profile:bflc:Agents:PrimaryContribution']"
+          ]
+        },
+        "useValuesFrom": {
+          "type": "array",
+          "title": "Use Values From (these URIs)",
+          "description": "Array of Authority URIs or Vocabulary Lookup API identifiers to perform a lookup against.",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "['http://id.loc.gov/authorities/names', 'http://mlvlp04.loc.gov:8230/resources/works', 'http://id.loc.gov/authorities/genreForms']"
+          ]
+        },
+        "valueDataType": {
+          "type": "object",
+          "title": "Value Data Types",
+          "description": "Data Type information - Type URI and comments primarily.",
+          "required": [],
+          "properties": {
+            "dataTypeURI": {
+              "type": "string",
+              "format": "uri",
+              "title": "Data Type URI",
+              "description": "URI for the Data Type of the Lookup Value in this value template.",
+              "example": [
+                "http://id.loc.gov/ontologies/bibframe/Work",
+                "http://id.loc.gov/ontologies/bflc/PrimaryContribution",
+                "http://www.loc.gov/mads/rdf/v1#Affiliation"
+              ]
+            },
+            "dataTypeLabel": {
+              "type": "string",
+              "title": "dataType Label",
+              "description": "Preferred, human readable label associated with the DataType.  Ignored."
+            },
+            "dataTypeLabelHint": {
+              "type": "string",
+              "title": "dataType LabelHint",
+              "description": "Short, human readable label for display purposes.  Ignored."
+            },
+            "remark": {
+              "type": "string",
+              "title": "dataType remark",
+              "description": "Comment or guiding statement intended to be presented as supplementary information in user display.  Ignored."
+            }
+          }
+        },
+        "defaults": {
+          "type": "array",
+          "title": "array of default values",
+          "description": "array of default values each comprised of default literal and URI",
+          "items": {
+            "type": "object",
+            "title": "default Literal + URI",
+            "description": "a default value is specified with a literal and a URI",
+            "required": ["defaultURI", "defaultLiteral"],
+            "properties": {
+              "defaultURI": {
+                "type": "string",
+                "format": "uri",
+                "title": "Default URI",
+                "description": "default value URI"
+              },
+              "defaultLiteral": {
+                "type": "string",
+                "title": "Default Literal",
+                "description": "default literal value"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/bfe-verso-profiles/schemas/property-templates-array.json
+++ b/bfe-verso-profiles/schemas/property-templates-array.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "property-templates-array",
+  "title": "LC Property Template Array Schema (i.e. Multiple Property Templates) (by Sinopia)",
+  "version": "0.0.1",
+  "type": "array",
+  "items": {
+    "$ref": "property-template"
+  }
+}

--- a/bfe-verso-profiles/schemas/property-templates-array.json
+++ b/bfe-verso-profiles/schemas/property-templates-array.json
@@ -6,5 +6,6 @@
   "type": "array",
   "items": {
     "$ref": "property-template"
-  }
+  },
+  "minItems": 1
 }

--- a/bfe-verso-profiles/schemas/resource-template.json
+++ b/bfe-verso-profiles/schemas/resource-template.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "resource-template",
+  "type": "object",
+  "title": "LC Resource Template Schema (by Sinopia)",
+  "version": "0.0.1",
+  "description": "A Resource Template construct (or hash) describes one of the various Sinopia entities (Works, Instances, Agent, etc.) associated with a given entity type and set of properties asserted against the entity.",
+  "required": [
+    "id",
+    "resourceURI",
+    "resourceLabel"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "title": "Resource Template Identifier",
+      "description": "Identifier associated with a resource template. Eventually, a URI.",
+      "example": [
+        "profile:bf2:AdminMetadata",
+        "http://sinopia.io/resources/common/AbstractResourceTemplate"
+      ]
+    },
+    "propertyTemplates": {
+      "$ref": "property-templates-array"
+    },
+    "remark": {
+      "type": "string",
+      "title": "Remark",
+      "description": "Comment or guiding statement intended to be presented as supplementary information in user display."
+    },
+    "resourceLabel": {
+      "type": "string",
+      "title": "Resource Label",
+      "description": "Preferred, human readable label associated with the resource template.",
+      "example": [
+        "BIBFRAME 2.0 Admin Metadata"
+      ]
+    },
+    "resourceURI": {
+      "type": "string",
+      "format": "uri",
+      "title": "Resource URI",
+      "description": "URI of the RDF resource type associated with the entity managed by this Resource Template.",
+      "example": [
+        "http://id.loc.gov/ontologies/bibframe/AdminMetadata"
+      ]
+    }
+  }
+}

--- a/bfe-verso-profiles/schemas/resource-template.json
+++ b/bfe-verso-profiles/schemas/resource-template.json
@@ -8,7 +8,8 @@
   "required": [
     "id",
     "resourceURI",
-    "resourceLabel"
+    "resourceLabel",
+    "propertyTemplates"
   ],
   "properties": {
     "id": {

--- a/bfe-verso-profiles/schemas/resource-templates-array.json
+++ b/bfe-verso-profiles/schemas/resource-templates-array.json
@@ -6,5 +6,6 @@
   "type": "array",
   "items": {
     "$ref": "resource-template"
-  }
+  },
+  "minItems": 1
 }

--- a/bfe-verso-profiles/schemas/resource-templates-array.json
+++ b/bfe-verso-profiles/schemas/resource-templates-array.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "resource-templates-array",
+  "title": "LC Resource Template Array Schema (i.e. Multiple Resource Templates) (by Sinopia)",
+  "version": "0.0.1",
+  "type": "array",
+  "items": {
+    "$ref": "resource-template"
+  }
+}

--- a/schemas/profile.json
+++ b/schemas/profile.json
@@ -16,6 +16,7 @@
         "date",
         "description",
         "id",
+        "resourceTemplates",
         "title"
       ],
       "properties": {

--- a/schemas/property-templates-array.json
+++ b/schemas/property-templates-array.json
@@ -6,5 +6,6 @@
   "type": "array",
   "items": {
     "$ref": "property-template"
-  }
+  },
+  "minItems": 1
 }

--- a/schemas/resource-template.json
+++ b/schemas/resource-template.json
@@ -9,6 +9,7 @@
     "author",
     "date",
     "id",
+    "propertyTemplates",
     "resourceURI"
   ],
   "properties": {

--- a/schemas/resource-templates-array.json
+++ b/schemas/resource-templates-array.json
@@ -6,5 +6,6 @@
   "type": "array",
   "items": {
     "$ref": "resource-template"
-  }
+  },
+  "minItems": 1
 }


### PR DESCRIPTION
- based on Christina's schemas, bfe-verso JSON schemas have been set up so that the existing LC profiles pass with a minimum of tweaks.
- updated bfe-verso profiles as indicated in commit messages:
   - fixed 2 bad _type_ values in propertyTemplates
   - fixed profile that had _contact_ instead of _author_
   - got rid of empty (invalid) dataTypeURI strings by removing the valueDataType for those (nothing else is of consequence)

- also updated sinopia schemas so profile requires resourceTemplates array and resourceTemplate requires propertyTemplate array

Closes #11

FYI:  I have told @kirkhess about this PR so he can see what we did to LC's profiles to make them pass schema validation.  LC is also free to steal the schemas here, of course.
