### PR TITLE
Make Resource Template ID consistent with current v0.1.0 profiles

### DIFF
--- a/profiles/v0.1.0/SchemaThingProfile.json
+++ b/profiles/v0.1.0/SchemaThingProfile.json
@@ -90,7 +90,7 @@
             "remark": "URL of the item."
           }
         ],
-        "id": "schema:Thing",
+        "id": "sinopia:resourceTemplate:schema:Thing",
         "resourceURI": "http://schema.org/Thing",
         "resourceLabel": "The most generic type of item",
         "author": "Jeremy Nelson",


### PR DESCRIPTION
Makes Resource Template of `schema:Thing` consistent with other resource templates for **0.1.0** .